### PR TITLE
Ref:871961 - Remove Callback Filter

### DIFF
--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -279,8 +279,7 @@ namespace cv19ResSupportV3.V3.Gateways
             {
                 var response = _helpRequestsContext.HelpRequestEntities
                     .Where(x => (x.CallbackRequired == true || x.CallbackRequired == null ||
-                                 (x.InitialCallbackCompleted == false && x.CallbackRequired == false))
-                                && x.DateTimeRecorded < DateTime.Today)
+                                 (x.InitialCallbackCompleted == false && x.CallbackRequired == false)))
                     .OrderByDescending(x => x.InitialCallbackCompleted)
                     .ThenBy(x => x.DateTimeRecorded)
                     .ToList();


### PR DESCRIPTION
This PR removes the filter on help request callbacks that restricts callbacks to those that are one day or older.

This was done as there has been a request to have callbacks available the same they they are created as there is sufficient capacity to handle these.