### PR TITLE
Fix docker-compose database name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - 3000:3000
     environment:
-      - CONNECTION_STRING=Host=dev-database;Port=5432;Database=entitycorex;Username=postgres;Password=mypassword
+      - CONNECTION_STRING=Host=dev-database;Port=5432;Database=testdb;Username=postgres;Password=mypassword
     links:
       - dev-database
   dev-database:


### PR DESCRIPTION
# What

Update database name to match the test db

# Why

So we can run the API locally without any problems

# Ticket

n/a