### PR TITLE
Add security groups to development and production environments

### DIFF
--- a/cv19ResSupportV3/serverless.yml
+++ b/cv19ResSupportV3/serverless.yml
@@ -85,6 +85,8 @@ resources:
 custom:
   vpc:
     development:
+      securityGroupIds:
+        - sg-0295c6df4beffa609
       subnetIds:
         - subnet-0deabb5d8fb9c3446
         - subnet-000b89c249f12a8ad
@@ -93,6 +95,8 @@ custom:
         - subnet-06d3de1bd9181b0d7
         - subnet-0ed7d7713d1127656
     production:
+      securityGroupIds:
+        - sg-0e3ca1352f142d8c8
       subnetIds:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34


### PR DESCRIPTION
# What
Add security groups to development and production environments

# Why
To set up access to the RDS from lambda
To have the same set up in prod and dev

# Screenshots


# Link to ticket
https://trello.com/c/4OvCRFPP/62-as-an-outbound-shielding-caller-i-need-to-capture-the-residents-needs-each-time-i-speak-to-them

# Notes


