### PR TITLE
Add database migrations for a new calls table

### DIFF
--- a/cv19ResSupportV3/V3/Infrastructure/HelpRequestCallsEntity.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/HelpRequestCallsEntity.cs
@@ -1,0 +1,31 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace cv19ResSupportV3.V3.Infrastructure
+{
+
+    [Table("help_request_calls")]
+        public class HelpRequestCallsEntity
+        {
+            [Column("id")]
+            [Key]
+            public int Id { get; set; }
+
+
+            [Column("help_request_id")]
+            [ForeignKey("HelpRequestEntity")]
+            public int HelpRequestId { get; set; }
+
+            [Column("call_type")]
+            public string CallType { get; set; }
+
+            [Column("call_outcome")]
+            public string CallOutcome { get; set; }
+
+            [Column("call_date_time")]
+            public DateTime? CallDateTime { get; set; }
+
+            public HelpRequestEntity HelpRequestEntity { get; set; }
+        }
+}

--- a/cv19ResSupportV3/V3/Infrastructure/HelpRequestsContext.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/HelpRequestsContext.cs
@@ -11,6 +11,8 @@ namespace cv19ResSupportV3.V3.Infrastructure
         }
         public DbSet<HelpRequestEntity> HelpRequestEntities { get; set; }
         public DbSet<LookupEntity> Lookups { get; set; }
+        public DbSet<HelpRequestCallsEntity> HelpRequestCallsEntities { get; set; }
+
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -202,6 +204,22 @@ namespace cv19ResSupportV3.V3.Infrastructure
                             .HasColumnType("character varying");;
                     }
                 );
+                        modelBuilder.Entity<HelpRequestCallsEntity>(entity =>
+                            {
+                                entity.ToTable("help_request_calls");
+                                entity.HasKey(call => new {call.Id});
+                                entity.Property(e => e.Id).HasColumnName("id");
+                                entity.Property(e => e.HelpRequestId).HasColumnName("help_request_id");
+                                entity.Property(e => e.CallType)
+                                    .HasColumnName("call_type")
+                                    .HasColumnType("character varying");
+                                entity.Property(e => e.CallOutcome)
+                                    .HasColumnName("call_outcome")
+                                    .HasColumnType("character varying");
+                                entity.Property(e => e.CallDateTime)
+                                    .HasColumnName("call_date_time");
+                            }
+                        );
         }
     }
 }

--- a/cv19ResSupportV3/V3/Infrastructure/Migrations/20201119115446_AddCallsTable.Designer.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/Migrations/20201119115446_AddCallsTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using cv19ResSupportV3.V3.Infrastructure;
@@ -9,9 +10,10 @@ using cv19ResSupportV3.V3.Infrastructure;
 namespace cv19ResSupportV3.V3.Infrastructure.Migrations
 {
     [DbContext(typeof(HelpRequestsContext))]
-    partial class HelpRequestsContextModelSnapshot : ModelSnapshot
+    [Migration("20201119115446_AddCallsTable")]
+    partial class AddCallsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -311,7 +313,7 @@ namespace cv19ResSupportV3.V3.Infrastructure.Migrations
             modelBuilder.Entity("cv19ResSupportV3.V3.Infrastructure.HelpRequestCallsEntity", b =>
                 {
                     b.HasOne("cv19ResSupportV3.V3.Infrastructure.HelpRequestEntity", "HelpRequestEntity")
-                        .WithMany()
+                        .WithMany("HelpRequestCallsEntities")
                         .HasForeignKey("HelpRequestId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();

--- a/cv19ResSupportV3/V3/Infrastructure/Migrations/20201119115446_AddCallsTable.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/Migrations/20201119115446_AddCallsTable.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace cv19ResSupportV3.V3.Infrastructure.Migrations
+{
+    public partial class AddCallsTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "help_request_calls",
+                columns: table => new
+                {
+                    id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    help_request_id = table.Column<int>(nullable: false),
+                    call_type = table.Column<string>(type: "character varying", nullable: true),
+                    call_outcome = table.Column<string>(type: "character varying", nullable: true),
+                    call_date_time = table.Column<DateTime>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_help_request_calls", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_help_request_calls_i_need_help_resident_support_v3_help_req~",
+                        column: x => x.help_request_id,
+                        principalTable: "i_need_help_resident_support_v3",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_help_request_calls_help_request_id",
+                table: "help_request_calls",
+                column: "help_request_id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "help_request_calls");
+        }
+    }
+}


### PR DESCRIPTION
# What
Add `help_request_calls` table using db migrations.
The table has the following columns:

- Call id - int
- Help request id - int
- Call direction/type - string
- Call outcome - string
- Time of the call - datetime

`HelpRequestId("help_request_id")` field links to the `id` in the `i_need_help_resident_support_v3` table

# Why
To provide a place where individual call attempts to the residents and their outcomes could be stored

# Screenshots
<img width="529" alt="image" src="https://user-images.githubusercontent.com/54268893/99664457-1d326100-2a60-11eb-8796-f349589b3a5d.png">


# Link to ticket
https://trello.com/c/KFlXvf6f/56-as-an-outbound-shielding-caller-i-need-to-record-each-time-i-make-a-call-and-the-action-of-that-call

# Notes


