### PR TITLE
Feature/get help request calls

### DIFF
--- a/cv19ResSupportV3.Tests/V3/Controllers/HelpRequestCallControllerTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Controllers/HelpRequestCallControllerTest.cs
@@ -26,7 +26,7 @@ namespace cv19ResRupportV3.Tests.V3.Controllers
         {
             _fakeCreateHelpRequestCallUseCase = new Mock<ICreateHelpRequestCallUseCase>();
             _fakeGetHelpRequestCallsUseCase = new Mock<IGetHelpRequestCallsUseCase>();
-            _classUnderTest = new HelpRequestCallController(_fakeCreateHelpRequestCallUseCase.Object, _fakeGetHelpRequestCallsUseCase.Object );
+            _classUnderTest = new HelpRequestCallController(_fakeCreateHelpRequestCallUseCase.Object, _fakeGetHelpRequestCallsUseCase.Object);
         }
 
         [Test]
@@ -48,7 +48,7 @@ namespace cv19ResRupportV3.Tests.V3.Controllers
             var id = 1;
             _fakeGetHelpRequestCallsUseCase.Setup(x => x.Execute(id))
                 .Returns(new List<CallGetResponse>() { });
-            var response = _classUnderTest.GetCalls(id) as OkObjectResult;;
+            var response = _classUnderTest.GetCalls(id) as OkObjectResult; ;
             _fakeGetHelpRequestCallsUseCase.Verify(mock => mock.Execute(id), Times.Once());
             response.StatusCode.Should().Be(200);
         }

--- a/cv19ResSupportV3.Tests/V3/Controllers/HelpRequestCallControllerTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Controllers/HelpRequestCallControllerTest.cs
@@ -19,12 +19,14 @@ namespace cv19ResRupportV3.Tests.V3.Controllers
     {
         private HelpRequestCallController _classUnderTest;
         private Mock<ICreateHelpRequestCallUseCase> _fakeCreateHelpRequestCallUseCase;
+        private Mock<IGetHelpRequestCallsUseCase> _fakeGetHelpRequestCallsUseCase;
 
         [SetUp]
         public void SetUp()
         {
             _fakeCreateHelpRequestCallUseCase = new Mock<ICreateHelpRequestCallUseCase>();
-            _classUnderTest = new HelpRequestCallController(_fakeCreateHelpRequestCallUseCase.Object);
+            _fakeGetHelpRequestCallsUseCase = new Mock<IGetHelpRequestCallsUseCase>();
+            _classUnderTest = new HelpRequestCallController(_fakeCreateHelpRequestCallUseCase.Object, _fakeGetHelpRequestCallsUseCase.Object );
         }
 
         [Test]
@@ -37,6 +39,18 @@ namespace cv19ResRupportV3.Tests.V3.Controllers
                 .Returns(new HelpRequestCallCreateResponse() { Id = request.Id });
             var response = _classUnderTest.CreateHelpRequestCall(helpRequest.Id, request) as CreatedResult;
             response.StatusCode.Should().Be(201);
+        }
+
+
+        [Test]
+        public void GetCallsEndpointReturnsResponseWithStatus()
+        {
+            var id = 1;
+            _fakeGetHelpRequestCallsUseCase.Setup(x => x.Execute(id))
+                .Returns(new List<CallGetResponse>() { });
+            var response = _classUnderTest.GetCalls(id) as OkObjectResult;;
+            _fakeGetHelpRequestCallsUseCase.Verify(mock => mock.Execute(id), Times.Once());
+            response.StatusCode.Should().Be(200);
         }
     }
 }

--- a/cv19ResSupportV3.Tests/V3/Controllers/HelpRequestCallControllerTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Controllers/HelpRequestCallControllerTest.cs
@@ -52,5 +52,25 @@ namespace cv19ResRupportV3.Tests.V3.Controllers
             _fakeGetHelpRequestCallsUseCase.Verify(mock => mock.Execute(id), Times.Once());
             response.StatusCode.Should().Be(200);
         }
+
+        [Test]
+        public void GetCallsReturns404InCaseOfInvalidOperationException()
+        {
+            var id = 112;
+            _fakeGetHelpRequestCallsUseCase.Setup(x => x.Execute(id))
+                .Throws(new InvalidOperationException());
+            var response = _classUnderTest.GetCalls(id) as NotFoundObjectResult;
+            response.StatusCode.Should().Be(404);
+        }
+
+        [Test]
+        public void GetCallsReturns400InCaseOfException()
+        {
+            var id = 112;
+            _fakeGetHelpRequestCallsUseCase.Setup(x => x.Execute(id))
+                .Throws(new Exception());
+            var response = _classUnderTest.GetCalls(id) as BadRequestObjectResult;
+            response.StatusCode.Should().Be(400);
+        }
     }
 }

--- a/cv19ResSupportV3.Tests/V3/E2ETests/GetCalls.cs
+++ b/cv19ResSupportV3.Tests/V3/E2ETests/GetCalls.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using cv19ResSupportV3.Tests.V3.Helper;
+using cv19ResSupportV3.Tests.V3.Helpers;
+using cv19ResSupportV3.V3.Boundary.Response;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V3.E2ETests
+{
+    public class GetCalls : IntegrationTests<Startup>
+    {
+
+        [SetUp]
+        public void SetUp()
+        {
+            CustomizeAssertions.ApproximationDateTime();
+            DatabaseContext.Database.RollbackTransaction();
+            E2ETestHelpers.ClearTable(DatabaseContext);
+        }
+
+
+        [Test]
+        public async Task ReturnsNoCallsIfNoCallsExistForAHelpRequest()
+        {
+            var helpRequest = EntityHelpers.createHelpRequestEntity();
+            helpRequest.CallbackRequired = true;
+            helpRequest.InitialCallbackCompleted = true;
+            helpRequest.DateTimeRecorded = DateTime.Today.AddDays(-2);
+            DatabaseContext.HelpRequestEntities.Add(helpRequest);
+
+            DatabaseContext.SaveChanges();
+            var requestUri = new Uri($"api/v3/help-requests/{helpRequest.Id}/calls", UriKind.Relative);
+            var response = Client.GetAsync(requestUri);
+            var statusCode = response.Result.StatusCode;
+            statusCode.Should().Be(200);
+            var responseBody = response.Result.Content;
+            var stringResponse = await responseBody.ReadAsStringAsync().ConfigureAwait(true);
+            var deserializedBody = JsonConvert.DeserializeObject<List<CallGetResponse>>(stringResponse);
+            DatabaseContext.HelpRequestEntities.Find(helpRequest.Id).HelpRequestCalls.Count.Should().Be(0);
+            deserializedBody.Count.Should().Be(0);
+        }
+    }
+}

--- a/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestCallGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestCallGatewayTest.cs
@@ -22,7 +22,7 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
         [Test]
         public void CreateHelpRequestCallReturnsTheRequestIfCreated()
         {
-            DatabaseContext.HelpRequestEntities.Add(EntityHelpers.createHelpRequestEntity());
+            DatabaseContext.HelpRequestEntities.Add(EntityHelpers.createHelpRequestEntity(2));
             DatabaseContext.SaveChanges();
             var helpRequestEntity = DatabaseContext.HelpRequestEntities.First();
             var helpRequestCall = EntityHelpers.createHelpRequestCallEntity();
@@ -35,11 +35,8 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
         public void GetCallsReturnsEmptyListIfNoCallsExist()
         {
             var id = 123;
-//            DatabaseContext.HelpRequestEntities.Add(EntityHelpers.createHelpRequestEntity());
-//            DatabaseContext.SaveChanges();
-//            var helpRequestEntity = DatabaseContext.HelpRequestEntities.First();
-//            var helpRequestCall = EntityHelpers.createHelpRequestCallEntity();
-//            helpRequestCall.HelpRequestId = helpRequestEntity.Id;
+            DatabaseContext.HelpRequestEntities.Add(EntityHelpers.createHelpRequestEntity(id));
+            DatabaseContext.SaveChanges();
             var response = _classUnderTest.GetHelpRequestCalls(id);
             response.Should().BeNullOrEmpty();
         }

--- a/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestCallGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestCallGatewayTest.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.Linq;
 using cv19ResSupportV3.Tests.V3.Helpers;
 using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V3.Infrastructure;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -29,5 +31,17 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             response.Should().Be(helpRequestCall.Id);
         }
 
+        [Test]
+        public void GetCallsReturnsEmptyListIfNoCallsExist()
+        {
+            var id = 123;
+//            DatabaseContext.HelpRequestEntities.Add(EntityHelpers.createHelpRequestEntity());
+//            DatabaseContext.SaveChanges();
+//            var helpRequestEntity = DatabaseContext.HelpRequestEntities.First();
+//            var helpRequestCall = EntityHelpers.createHelpRequestCallEntity();
+//            helpRequestCall.HelpRequestId = helpRequestEntity.Id;
+            var response = _classUnderTest.GetHelpRequestCalls(id);
+            response.Should().BeNullOrEmpty();
+        }
     }
 }

--- a/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestCallGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestCallGatewayTest.cs
@@ -1,8 +1,7 @@
-using System.Collections.Generic;
+using System;
 using System.Linq;
 using cv19ResSupportV3.Tests.V3.Helpers;
 using cv19ResSupportV3.V3.Gateways;
-using cv19ResSupportV3.V3.Infrastructure;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -39,6 +38,15 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             DatabaseContext.SaveChanges();
             var response = _classUnderTest.GetHelpRequestCalls(id);
             response.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void GetCallsThrowsInvalidOperationExceptionIfHelpRequestWithGivenIdDoesNotExist()
+        {
+            var id = 111;
+            _classUnderTest.Invoking(y => y.GetHelpRequestCalls(id))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage("Operation is not valid due to the current state of the object.");
         }
     }
 }

--- a/cv19ResSupportV3.Tests/V3/Helpers/EntityHelpers.cs
+++ b/cv19ResSupportV3.Tests/V3/Helpers/EntityHelpers.cs
@@ -8,9 +8,10 @@ namespace cv19ResSupportV3.Tests.V3.Helpers
 {
     public static class EntityHelpers
     {
-        public static HelpRequestEntity createHelpRequestEntity()
+        public static HelpRequestEntity createHelpRequestEntity(int id = 1)
         {
             var helpRequestEntity = Randomm.Build<HelpRequestEntity>()
+                .With(i => i.Id, id)
                 .Without(h => h.HelpRequestCalls)
                 .Create();
             return helpRequestEntity;
@@ -31,5 +32,14 @@ namespace cv19ResSupportV3.Tests.V3.Helpers
                 .Without(h => h.HelpRequestEntity)
                 .Create();
         }
+
+        public static List<HelpRequestCallEntity> createHelpRequestCallEntities(int count = 3)
+        {
+            var calls = Randomm.Build<HelpRequestCallEntity>()
+                .Without(h => h.HelpRequestEntity).CreateMany(count).ToList();
+            return calls;
+
+        }
+
     }
 }

--- a/cv19ResSupportV3.Tests/V3/UseCase/GetHelpRequestCallsUseCaseTests.cs
+++ b/cv19ResSupportV3.Tests/V3/UseCase/GetHelpRequestCallsUseCaseTests.cs
@@ -26,7 +26,7 @@ namespace cv19ResSupportV3.Tests.V3.UseCase
         public void ReturnsPopulatedHelpRequestListIfParamsProvided()
         {
             var id = 1;
-            var stubbedResponse = new List<HelpRequestCallEntity>() {EntityHelpers.createHelpRequestCallEntity()};
+            var stubbedResponse = new List<HelpRequestCallEntity>() { EntityHelpers.createHelpRequestCallEntity() };
             _mockGateway.Setup(x => x.GetHelpRequestCalls(id)).Returns(stubbedResponse);
             var response = _classUnderTest.Execute(id);
             response.Should().NotBeNull();

--- a/cv19ResSupportV3.Tests/V3/UseCase/GetHelpRequestCallsUseCaseTests.cs
+++ b/cv19ResSupportV3.Tests/V3/UseCase/GetHelpRequestCallsUseCaseTests.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using cv19ResSupportV3.Tests.V3.Helpers;
+using cv19ResSupportV3.V3.Factories;
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V3.Infrastructure;
+using cv19ResSupportV3.V3.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V3.UseCase
+{
+    public class GetHelpRequestCallsUseCaseTests
+    {
+        private Mock<IHelpRequestCallGateway> _mockGateway;
+        private GetHelpRequestCallsUseCase _classUnderTest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockGateway = new Mock<IHelpRequestCallGateway>();
+            _classUnderTest = new GetHelpRequestCallsUseCase(_mockGateway.Object);
+        }
+
+        [Test]
+        public void ReturnsPopulatedHelpRequestListIfParamsProvided()
+        {
+            var id = 1;
+            var stubbedResponse = new List<HelpRequestCallEntity>() {EntityHelpers.createHelpRequestCallEntity()};
+            _mockGateway.Setup(x => x.GetHelpRequestCalls(id)).Returns(stubbedResponse);
+            var response = _classUnderTest.Execute(id);
+            response.Should().NotBeNull();
+            response.Should().BeEquivalentTo(stubbedResponse.ToResponse());
+        }
+    }
+}

--- a/cv19ResSupportV3/Startup.cs
+++ b/cv19ResSupportV3/Startup.cs
@@ -140,6 +140,7 @@ namespace cv19ResSupportV3
             services.AddScoped<IGetLookupsUseCase, GetLookupsUseCase>();
             services.AddScoped<ICreateHelpRequestUseCase, CreateHelpRequestUseCase>();
             services.AddScoped<ICreateHelpRequestCallUseCase, CreateHelpRequestCallUseCase>();
+            services.AddScoped<IGetHelpRequestCallsUseCase, GetHelpRequestCallsUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/cv19ResSupportV3/V3/Boundary/Response/CallGetResponse.cs
+++ b/cv19ResSupportV3/V3/Boundary/Response/CallGetResponse.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace cv19ResSupportV3.V3.Boundary.Response
+{
+    public class CallGetResponse
+    {
+        public int Id { get; set; }
+        public int HelpRequestId { get; set; }
+        public string CallType { get; set; }
+        public string CallOutcome { get; set; }
+        public DateTime CallDateTime { get; set; }
+    }
+}

--- a/cv19ResSupportV3/V3/Controllers/HelpRequestCallController.cs
+++ b/cv19ResSupportV3/V3/Controllers/HelpRequestCallController.cs
@@ -56,8 +56,19 @@ namespace cv19ResSupportV3.V3.Controllers
         [HttpGet]
         public IActionResult GetCalls(int id)
         {
-            var result = _getCallsUseCase.Execute(id);
-            return Ok(result);
+            try
+            {
+                var result = _getCallsUseCase.Execute(id);
+                return Ok(result);
+            }
+            catch (InvalidOperationException e)
+            {
+                return NotFound($"Record with id {id} not found");
+            }
+            catch (Exception e)
+            {
+                return BadRequest($"Could not get calls for help request {id}. {e}");
+            }
         }
     }
 }

--- a/cv19ResSupportV3/V3/Controllers/HelpRequestCallController.cs
+++ b/cv19ResSupportV3/V3/Controllers/HelpRequestCallController.cs
@@ -19,9 +19,12 @@ namespace cv19ResSupportV3.V3.Controllers
     public class HelpRequestCallController : BaseController
     {
         private readonly ICreateHelpRequestCallUseCase _createHelpRequestCallUseCase;
-        public HelpRequestCallController(ICreateHelpRequestCallUseCase createHelpRequestCallUseCase)
+        private readonly IGetHelpRequestCallsUseCase _getCallsUseCase;
+
+        public HelpRequestCallController(ICreateHelpRequestCallUseCase createHelpRequestCallUseCase, IGetHelpRequestCallsUseCase getCallsUseCase)
         {
             _createHelpRequestCallUseCase = createHelpRequestCallUseCase;
+            _getCallsUseCase = getCallsUseCase;
         }
 
         /// <summary>
@@ -48,6 +51,13 @@ namespace cv19ResSupportV3.V3.Controllers
             }
         }
 
-
+        [Route("{id}/calls")]
+        [ProducesResponseType(typeof(List<CallGetResponse>), StatusCodes.Status200OK)]
+        [HttpGet]
+        public IActionResult GetCalls(int id)
+        {
+            var result = _getCallsUseCase.Execute(id);
+            return Ok(result);
+        }
     }
 }

--- a/cv19ResSupportV3/V3/Factories/ResponseFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/ResponseFactory.cs
@@ -99,7 +99,7 @@ namespace cv19ResSupportV3.V3.Factories
             return responseList.Select(responseItem => responseItem.ToResponse()).ToList();
         }
 
-           public static CallGetResponse ToResponse(this HelpRequestCallEntity call)
+        public static CallGetResponse ToResponse(this HelpRequestCallEntity call)
         {
 
             return new CallGetResponse()

--- a/cv19ResSupportV3/V3/Factories/ResponseFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/ResponseFactory.cs
@@ -93,5 +93,23 @@ namespace cv19ResSupportV3.V3.Factories
         {
             return lookupEntities.Select(le => le.ToResponse()).ToList();
         }
+
+        public static List<CallGetResponse> ToResponse(this IEnumerable<HelpRequestCallEntity> responseList)
+        {
+            return responseList.Select(responseItem => responseItem.ToResponse()).ToList();
+        }
+
+           public static CallGetResponse ToResponse(this HelpRequestCallEntity call)
+        {
+
+            return new CallGetResponse()
+            {
+                Id = call.Id,
+                HelpRequestId = call.HelpRequestId,
+                CallType = call.CallType,
+                CallOutcome = call.CallOutcome,
+                CallDateTime = call.CallDateTime
+            };
+        }
     }
 }

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestCallGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestCallGateway.cs
@@ -43,6 +43,9 @@ namespace cv19ResSupportV3.V3.Gateways
             }
         }
 
-
+        public List<HelpRequestCallEntity> GetHelpRequestCalls(in int id)
+        {
+            return new List<HelpRequestCallEntity>();
+        }
     }
 }

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestCallGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestCallGateway.cs
@@ -45,10 +45,20 @@ namespace cv19ResSupportV3.V3.Gateways
 
         public List<HelpRequestCallEntity> GetHelpRequestCalls(int id)
         {
-            var helpRequest = _helpRequestsContext.HelpRequestEntities.Find(id);
-            if (helpRequest == null)
-                throw new InvalidOperationException();
-            return _helpRequestsContext.HelpRequestCallEntities.Where(q => q.HelpRequestId == id).ToList();
+            try
+            {
+                var helpRequest = _helpRequestsContext.HelpRequestEntities.Find(id);
+                if (helpRequest == null)
+                    throw new InvalidOperationException();
+                return _helpRequestsContext.HelpRequestCallEntities.Where(q => q.HelpRequestId == id).ToList();
+            }
+            catch (Exception e)
+            {
+                LambdaLogger.Log("GetHelpRequestCalls error: ");
+                LambdaLogger.Log(e.Message);
+                throw;
+            }
+
         }
     }
 }

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestCallGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestCallGateway.cs
@@ -43,9 +43,12 @@ namespace cv19ResSupportV3.V3.Gateways
             }
         }
 
-        public List<HelpRequestCallEntity> GetHelpRequestCalls(in int id)
+        public List<HelpRequestCallEntity> GetHelpRequestCalls(int id)
         {
-            return new List<HelpRequestCallEntity>();
+            var helpRequest = _helpRequestsContext.HelpRequestEntities.Find(id);
+            if (helpRequest == null)
+                throw new InvalidOperationException();
+            return _helpRequestsContext.HelpRequestCallEntities.Where(q => q.HelpRequestId == id).ToList();
         }
     }
 }

--- a/cv19ResSupportV3/V3/Gateways/IHelpRequestCallGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/IHelpRequestCallGateway.cs
@@ -8,5 +8,6 @@ namespace cv19ResSupportV3.V3.Gateways
     public interface IHelpRequestCallGateway
     {
         int CreateHelpRequestCall(int id, HelpRequestCallEntity request);
+        List<HelpRequestCallEntity> GetHelpRequestCalls(in int id);
     }
 }

--- a/cv19ResSupportV3/V3/Gateways/IHelpRequestCallGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/IHelpRequestCallGateway.cs
@@ -8,6 +8,6 @@ namespace cv19ResSupportV3.V3.Gateways
     public interface IHelpRequestCallGateway
     {
         int CreateHelpRequestCall(int id, HelpRequestCallEntity request);
-        List<HelpRequestCallEntity> GetHelpRequestCalls(in int id);
+        List<HelpRequestCallEntity> GetHelpRequestCalls(int id);
     }
 }

--- a/cv19ResSupportV3/V3/UseCase/GetHelpRequestCallsUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/GetHelpRequestCallsUseCase.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using cv19ResSupportV3.V3.Boundary.Requests;
+using cv19ResSupportV3.V3.Boundary.Response;
+using cv19ResSupportV3.V3.Factories;
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V3.UseCase.Interfaces;
+
+namespace cv19ResSupportV3.V3.UseCase
+{
+    public class GetHelpRequestCallsUseCase :IGetHelpRequestCallsUseCase
+    {
+        private readonly IHelpRequestCallGateway _gateway;
+
+        public GetHelpRequestCallsUseCase(IHelpRequestCallGateway gateway)
+        {
+            _gateway = gateway;
+        }
+        public List<CallGetResponse> Execute(int id)
+        {
+            return _gateway.GetHelpRequestCalls(id).ToResponse();
+        }
+    }
+}

--- a/cv19ResSupportV3/V3/UseCase/GetHelpRequestCallsUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/GetHelpRequestCallsUseCase.cs
@@ -7,7 +7,7 @@ using cv19ResSupportV3.V3.UseCase.Interfaces;
 
 namespace cv19ResSupportV3.V3.UseCase
 {
-    public class GetHelpRequestCallsUseCase :IGetHelpRequestCallsUseCase
+    public class GetHelpRequestCallsUseCase : IGetHelpRequestCallsUseCase
     {
         private readonly IHelpRequestCallGateway _gateway;
 

--- a/cv19ResSupportV3/V3/UseCase/Interfaces/IGetHelpRequestCallsUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/Interfaces/IGetHelpRequestCallsUseCase.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using cv19ResSupportV3.V3.Boundary.Response;
+
+namespace cv19ResSupportV3.V3.UseCase.Interfaces
+{
+    public interface IGetHelpRequestCallsUseCase
+    {
+        List<CallGetResponse> Execute(int id);
+    }
+}


### PR DESCRIPTION
# What
Add API endpoint that returns all the calls for help request

# Why
To expose a way to access calls data through this API

# Screenshots
This is what gets returned if a help request has calls associated with it (200):
<img width="403" alt="image" src="https://user-images.githubusercontent.com/54268893/100204926-62411200-2efc-11eb-84b5-3e4328501f4e.png">

If a help request has no calls associated with it (200):
<img width="178" alt="image" src="https://user-images.githubusercontent.com/54268893/100205035-84d32b00-2efc-11eb-98fd-44ea7e7b59d5.png">

If a help request with given ID does not exist (404):
<img width="364" alt="image" src="https://user-images.githubusercontent.com/54268893/100206365-227b2a00-2efe-11eb-90ac-afa090b7ec83.png">

Any other error (400 +the error message)
<img width="336" alt="image" src="https://user-images.githubusercontent.com/54268893/100206503-4fc7d800-2efe-11eb-99a4-4a7491956789.png">

# Link to ticket
https://trello.com/c/olhbGBsK/86-add-api-endpoint-that-returns-all-the-calls-for-help-request

# Notes


