### PR TITLE
Return calls with help request

### DIFF
--- a/cv19ResSupportV3.Tests/V3/E2ETests/GetCallbacks.cs
+++ b/cv19ResSupportV3.Tests/V3/E2ETests/GetCallbacks.cs
@@ -102,5 +102,36 @@ namespace cv19ResSupportV3.Tests.V3.E2ETests
             var deserializedBody = JsonConvert.DeserializeObject<List<HelpRequestGetResponse>>(stringResponse);
             deserializedBody.Count.Should().Be(expectedResponse);
         }
+
+        [Test]
+        public async Task GetCallbacksReturnsCallbacksWithHelpRequestCalls()
+        {
+            var helpRequest = EntityHelpers.createHelpRequestEntity();
+            var calls = EntityHelpers.createHelpRequestCallEntities();
+            helpRequest.CallbackRequired = true;
+            helpRequest.InitialCallbackCompleted = true;
+            helpRequest.DateTimeRecorded = DateTime.Today.AddDays(-2);
+
+            calls.ForEach(x => x.HelpRequestId = helpRequest.Id);
+            DatabaseContext.HelpRequestEntities.Add(helpRequest);
+            DatabaseContext.HelpRequestCallEntities.AddRange(calls);
+            DatabaseContext.SaveChanges();
+
+            var requestUri = new Uri($"api/v3/help-requests/callbacks", UriKind.Relative);
+            var response = Client.GetAsync(requestUri);
+            var statusCode = response.Result.StatusCode;
+            statusCode.Should().Be(200);
+            var responseBody = response.Result.Content;
+            var stringResponse = await responseBody.ReadAsStringAsync().ConfigureAwait(true);
+            var deserializedBody = JsonConvert.DeserializeObject<List<HelpRequestGetResponse>>(stringResponse);
+            DatabaseContext.HelpRequestEntities.Count().Should().Be(1);
+            deserializedBody.Count.Should().Be(1);
+            deserializedBody.First().HelpRequestCalls.Count.Should().Be(3);
+            deserializedBody.First().HelpRequestCalls.Should().BeEquivalentTo(calls, options =>
+            {
+                options.Excluding(ex => ex.HelpRequestEntity);
+                return options;
+            });
+        }
     }
 }

--- a/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestCallGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestCallGatewayTest.cs
@@ -20,7 +20,7 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
         [Test]
         public void CreateHelpRequestCallReturnsTheRequestIfCreated()
         {
-            DatabaseContext.HelpRequestEntities.Add(EntityHelpers.createHelpRequestEntity());
+            DatabaseContext.HelpRequestEntities.Add(EntityHelpers.createHelpRequestEntity(5));
             DatabaseContext.SaveChanges();
             var helpRequestEntity = DatabaseContext.HelpRequestEntities.First();
             var helpRequestCall = EntityHelpers.createHelpRequestCallEntity();

--- a/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
@@ -1,5 +1,7 @@
+using System.Linq;
 using AutoFixture;
 using cv19ResSupportV3.Tests.V3.Helpers;
+using cv19ResSupportV3.V3.Boundary.Requests;
 using cv19ResSupportV3.V3.Domain;
 using cv19ResSupportV3.V3.Factories;
 using cv19ResSupportV3.V3.Gateways;
@@ -95,6 +97,24 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             var response = _classUnderTest.GetHelpRequest(id);
             response.HelpRequestCalls.Count.Should().Be(3);
             response.HelpRequestCalls.Should().BeEquivalentTo(calls);
+        }
+
+        [Test]
+        public void GetAllCallbacksWithCallsListIfCallsExist()
+        {
+            var id = 124;
+            var helpRequest = EntityHelpers.createHelpRequestEntity(id);
+            DatabaseContext.HelpRequestEntities.Add(helpRequest);
+            helpRequest.CallbackRequired = true;
+
+            var calls = EntityHelpers.createHelpRequestCallEntities(3);
+            calls.ForEach(x => x.HelpRequestId = id);
+            DatabaseContext.HelpRequestCallEntities.AddRange(calls);
+            DatabaseContext.SaveChanges();
+            var response = _classUnderTest.GetCallbacks(new CallbackRequestParams() { HelpNeeded = "" });
+
+            response.First().HelpRequestCalls.Count.Should().Be(3);
+            response.First().HelpRequestCalls.Should().BeEquivalentTo(calls);
         }
     }
 }

--- a/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
@@ -34,10 +34,26 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
         [Test]
         public void CreateDuplicateHelpRequestTheLatestAsMaster()
         {
-            var helpRequest = _fixture.Create<HelpRequest>();
-            helpRequest.Id = 0;
+            var helpRequest = _fixture.Build<HelpRequest>()
+                .With(x => x.Uprn, "123")
+                .With(x => x.DobMonth, "123")
+                .With(x => x.DobDay, "123")
+                .With(x => x.DobYear, "123")
+                .With(x => x.ContactTelephoneNumber, "123")
+                .With(x => x.ContactMobileNumber, "123")
+                .Create();
+
+            var helpRequest2 = _fixture.Build<HelpRequest>()
+                .With(x => x.Uprn, "123")
+                .With(x => x.DobMonth, "123")
+                .With(x => x.DobDay, "123")
+                .With(x => x.DobYear, "123")
+                .With(x => x.ContactTelephoneNumber, "123")
+                .With(x => x.ContactMobileNumber, "123")
+                .Create();
+
             var response1 = _classUnderTest.CreateHelpRequest(helpRequest.ToEntity());
-            var response2 = _classUnderTest.CreateHelpRequest(helpRequest.ToEntity());
+            var response2 = _classUnderTest.CreateHelpRequest(helpRequest2.ToEntity());
             var firstRecordToCheck = DatabaseContext.HelpRequestEntities.Find(response1);
             var secondRecordToCheck = DatabaseContext.HelpRequestEntities.Find(response2);
             firstRecordToCheck.RecordStatus.Should().Be("DUPLICATE");

--- a/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
@@ -116,5 +116,19 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             response.First().HelpRequestCalls.Count.Should().Be(3);
             response.First().HelpRequestCalls.Should().BeEquivalentTo(calls);
         }
+
+        [Test]
+        public void SearchRequestsReturnsCallsListIfCallsExist()
+        {
+            var id = 124;
+            DatabaseContext.HelpRequestEntities.Add(EntityHelpers.createHelpRequestEntity(id));
+            var calls = EntityHelpers.createHelpRequestCallEntities(3);
+            calls.ForEach(x => x.HelpRequestId = id);
+            DatabaseContext.HelpRequestCallEntities.AddRange(calls);
+            DatabaseContext.SaveChanges();
+            var response = _classUnderTest.SearchHelpRequests(new RequestQueryParams());
+            response.First().HelpRequestCalls.Count.Should().Be(3);
+            response.First().HelpRequestCalls.Should().BeEquivalentTo(calls);
+        }
     }
 }

--- a/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
@@ -5,7 +5,6 @@ using cv19ResSupportV3.V3.Factories;
 using cv19ResSupportV3.V3.Gateways;
 using cv19ResSupportV3.V3.Infrastructure;
 using FluentAssertions;
-using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace cv19ResSupportV3.Tests.V3.Gateways
@@ -72,7 +71,30 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             updatedEntity.HelpWithShieldingGuidance.Should().Be(false);
             updatedEntity.HelpWithNoNeedsIdentified.Should().Be(true);
             updatedEntity.HelpWithAccessingSupermarketFood.Should().Be(false);
+        }
 
+        [Test]
+        public void GetHelpRequestReturnsEmptyCallsListIfNoCallsExist()
+        {
+            var id = 123;
+            DatabaseContext.HelpRequestEntities.Add(EntityHelpers.createHelpRequestEntity(id));
+            DatabaseContext.SaveChanges();
+            var response = _classUnderTest.GetHelpRequest(id);
+            response.HelpRequestCalls.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void GetHelpRequestReturnsCallsListIfCallsExist()
+        {
+            var id = 124;
+            DatabaseContext.HelpRequestEntities.Add(EntityHelpers.createHelpRequestEntity(id));
+            var calls = EntityHelpers.createHelpRequestCallEntities(3);
+            calls.ForEach(x => x.HelpRequestId = id);
+            DatabaseContext.HelpRequestCallEntities.AddRange(calls);
+            DatabaseContext.SaveChanges();
+            var response = _classUnderTest.GetHelpRequest(id);
+            response.HelpRequestCalls.Count.Should().Be(3);
+            response.HelpRequestCalls.Should().BeEquivalentTo(calls);
         }
     }
 }

--- a/cv19ResSupportV3.Tests/V3/Helpers/EntityHelpers.cs
+++ b/cv19ResSupportV3.Tests/V3/Helpers/EntityHelpers.cs
@@ -8,9 +8,10 @@ namespace cv19ResSupportV3.Tests.V3.Helpers
 {
     public static class EntityHelpers
     {
-        public static HelpRequestEntity createHelpRequestEntity()
+        public static HelpRequestEntity createHelpRequestEntity(int id = 1)
         {
             var helpRequestEntity = Randomm.Build<HelpRequestEntity>()
+                .With(x => x.Id, id)
                 .Without(h => h.HelpRequestCalls)
                 .Create();
             return helpRequestEntity;
@@ -30,6 +31,13 @@ namespace cv19ResSupportV3.Tests.V3.Helpers
             return Randomm.Build<HelpRequestCallEntity>()
                 .Without(h => h.HelpRequestEntity)
                 .Create();
+        }
+
+        public static List<HelpRequestCallEntity> createHelpRequestCallEntities(int count = 3)
+        {
+            var calls = Randomm.Build<HelpRequestCallEntity>()
+                .Without(h => h.HelpRequestEntity).CreateMany(count).ToList();
+            return calls;
         }
     }
 }

--- a/cv19ResSupportV3.Tests/V3/UseCase/GetHelpRequestUseCaseTests.cs
+++ b/cv19ResSupportV3.Tests/V3/UseCase/GetHelpRequestUseCaseTests.cs
@@ -30,5 +30,22 @@ namespace cv19ResSupportV3.Tests.V3.UseCase
             response.Should().NotBeNull();
             response.Should().BeEquivalentTo(stubbedRequest.ToResponse());
         }
+
+        [Test]
+        public void ReturnsASingleHelpRequestWithCalls()
+        {
+            var stubbedRequest = EntityHelpers.createHelpRequestEntity(5);
+            var calls = EntityHelpers.createHelpRequestCallEntities();
+            calls.ForEach(x => x.HelpRequestId = 5);
+            stubbedRequest.HelpRequestCalls = calls;
+            _mockGateway.Setup(x => x.GetHelpRequest(It.IsAny<int>())).Returns(stubbedRequest);
+            var response = _classUnderTest.Execute(stubbedRequest.Id);
+            response.Should().NotBeNull();
+            response.HelpRequestCalls.Should().BeEquivalentTo(calls, options =>
+            {
+                options.Excluding(ex => ex.HelpRequestEntity);
+                return options;
+            });
+        }
     }
 }

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -310,21 +310,6 @@ namespace cv19ResSupportV3.V3.Gateways
             }
         }
 
-        public List<HelpRequestEntity> GetHelpRequests()
-        {
-            try
-            {
-                return _helpRequestsContext.HelpRequestEntities.ToList();
-            }
-            catch (Exception e)
-            {
-                LambdaLogger.Log("GetHelpRequests error: ");
-                LambdaLogger.Log(e.Message);
-                throw;
-            }
-
-        }
-
         public List<HelpRequestEntity> GetCallbacks(CallbackRequestParams requestParams)
         {
             Expression<Func<HelpRequestEntity, bool>> queryHelpNeeded = x =>

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -7,6 +7,7 @@ using cv19ResSupportV3.V3.Boundary.Requests;
 using cv19ResSupportV3.V3.Factories;
 using cv19ResSupportV3.V3.Gateways;
 using cv19ResSupportV3.V3.Infrastructure;
+using Microsoft.EntityFrameworkCore;
 using HelpRequest = cv19ResSupportV3.V3.Domain.HelpRequest;
 
 namespace cv19ResSupportV3.V3.Gateways
@@ -85,8 +86,8 @@ namespace cv19ResSupportV3.V3.Gateways
             try
             {
                 var result = _helpRequestsContext.HelpRequestEntities
+                    .Include(x => x.HelpRequestCalls)
                     .FirstOrDefault(x => x.Id == id);
-                if (result != null) result.HelpRequestCalls = _helpRequestsContext.HelpRequestCallEntities.Where(q => q.HelpRequestId == id).ToList();
                 return result;
             }
             catch (Exception e)

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -84,8 +84,10 @@ namespace cv19ResSupportV3.V3.Gateways
         {
             try
             {
-                return _helpRequestsContext.HelpRequestEntities
+                var result = _helpRequestsContext.HelpRequestEntities
                     .FirstOrDefault(x => x.Id == id);
+                if (result != null) result.HelpRequestCalls = _helpRequestsContext.HelpRequestCallEntities.Where(q => q.HelpRequestId == id).ToList();
+                return result;
             }
             catch (Exception e)
             {

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -119,6 +119,7 @@ namespace cv19ResSupportV3.V3.Gateways
             try
             {
                 return _helpRequestsContext.HelpRequestEntities
+                    .Include(x => x.HelpRequestCalls)
                     .Where(queryPostCode)
                     .Where(queryFirstName)
                     .Where(queryLastName)

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -331,7 +331,7 @@ namespace cv19ResSupportV3.V3.Gateways
                 || x.HelpNeeded.Replace(" ", "").ToUpper().Equals(requestParams.HelpNeeded.Replace(" ", "").ToUpper());
             try
             {
-                var response = _helpRequestsContext.HelpRequestEntities
+                var response = _helpRequestsContext.HelpRequestEntities.Include(x => x.HelpRequestCalls)
                     .Where(x => (x.CallbackRequired == true || x.CallbackRequired == null ||
                                  (x.InitialCallbackCompleted == false && x.CallbackRequired == false)))
                     .Where(queryHelpNeeded)

--- a/cv19ResSupportV3/V3/Gateways/IHelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/IHelpRequestGateway.cs
@@ -9,7 +9,6 @@ namespace cv19ResSupportV3.V3.Gateways
     {
         int CreateHelpRequest(HelpRequestEntity request);
         List<LookupEntity> GetLookups(LookupQueryParams requestParams);
-        List<HelpRequestEntity> GetHelpRequests();
         List<HelpRequestEntity> GetCallbacks(CallbackRequestParams requestParams);
         HelpRequestEntity UpdateHelpRequest(HelpRequestEntity request);
         HelpRequestEntity GetHelpRequest(int id);


### PR DESCRIPTION
# What
Return HelpRequestCalls as part of HelpRequest for the get help request, search help request and get callbacks.

# Why
To expose information about help request calls through this API.

# Screenshots
<img width="770" alt="image" src="https://user-images.githubusercontent.com/54268893/100263970-1450fc00-2f46-11eb-807e-82158eabe1d4.png">

# Link to ticket
https://trello.com/c/olhbGBsK/86-add-api-endpoint-that-returns-all-the-calls-for-help-request

# Notes
Also remove GetHelpRequests method from HelpRequestsGateway, because it wasn't being used and prevent test for duplicates from using same ID, because it keeps on failing on circleCI.

Gateway tests pass with and without: `.Include(x => x.HelpRequestCalls)`
However E2E tests require this line. Data seems to be loaded differently by entity framework for these two cases, might need further investigation.
