### PR TITLE
Rename caller to call handler

### DIFF
--- a/cv19ResSupportV3/V3/Domain/HelpRequestCall.cs
+++ b/cv19ResSupportV3/V3/Domain/HelpRequestCall.cs
@@ -10,5 +10,7 @@ namespace cv19ResSupportV3.V3.Domain
         public string CallDirection { get; set; }
         public string CallOutcome { get; set; }
         public DateTime CallDateTime { get; set; }
+
+        public string CallHandler { get; set; }
     }
 }

--- a/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
@@ -145,7 +145,8 @@ namespace cv19ResSupportV3.V3.Factories
                 CallType = helpRequestCall.CallType,
                 CallDirection = helpRequestCall.CallDirection,
                 CallOutcome = helpRequestCall.CallOutcome,
-                CallDateTime = helpRequestCall.CallDateTime
+                CallDateTime = helpRequestCall.CallDateTime,
+                CallHandler = helpRequestCall.CallHandler
             };
         }
 
@@ -158,7 +159,8 @@ namespace cv19ResSupportV3.V3.Factories
                 CallType = helpRequestCallEntity.CallType,
                 CallDirection = helpRequestCallEntity.CallDirection,
                 CallOutcome = helpRequestCallEntity.CallOutcome,
-                CallDateTime = helpRequestCallEntity.CallDateTime
+                CallDateTime = helpRequestCallEntity.CallDateTime,
+                CallHandler = helpRequestCallEntity.CallHandler
             };
         }
 

--- a/cv19ResSupportV3/V3/Infrastructure/HelpRequestCallEntity.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/HelpRequestCallEntity.cs
@@ -26,6 +26,9 @@ namespace cv19ResSupportV3.V3.Infrastructure
         [Column("call_date_time")]
         public DateTime CallDateTime { get; set; }
 
+        [Column("call_handler")]
+        public string CallHandler { get; set; }
+
         public HelpRequestEntity HelpRequestEntity { get; set; }
 
     }

--- a/cv19ResSupportV3/V3/Infrastructure/HelpRequestsContext.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/HelpRequestsContext.cs
@@ -221,6 +221,9 @@ namespace cv19ResSupportV3.V3.Infrastructure
                         .HasColumnType("character varying");
                     entity.Property(e => e.CallDateTime)
                         .HasColumnName("call_date_time");
+                    entity.Property(e => e.CallHandler)
+                        .HasColumnName("call_handler")
+                        .HasColumnType("character varying");
                     entity.HasOne(e => e.HelpRequestEntity)
                         .WithMany(c => c.HelpRequestCalls);
                 }

--- a/cv19ResSupportV3/V3/Infrastructure/Migrations/20201127151202_AddCallerToCallsTable.Designer.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/Migrations/20201127151202_AddCallerToCallsTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using cv19ResSupportV3.V3.Infrastructure;
@@ -9,9 +10,10 @@ using cv19ResSupportV3.V3.Infrastructure;
 namespace cv19ResSupportV3.V3.Infrastructure.Migrations
 {
     [DbContext(typeof(HelpRequestsContext))]
-    partial class HelpRequestsContextModelSnapshot : ModelSnapshot
+    [Migration("20201127151202_AddCallerToCallsTable")]
+    partial class AddCallerToCallsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -43,8 +45,8 @@ namespace cv19ResSupportV3.V3.Infrastructure.Migrations
                         .HasColumnName("call_type")
                         .HasColumnType("character varying");
 
-                    b.Property<string>("CallHandler")
-                        .HasColumnName("call_handler")
+                    b.Property<string>("Caller")
+                        .HasColumnName("caller")
                         .HasColumnType("character varying");
 
                     b.Property<int>("HelpRequestId")

--- a/cv19ResSupportV3/V3/Infrastructure/Migrations/20201127151202_AddCallerToCallsTable.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/Migrations/20201127151202_AddCallerToCallsTable.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace cv19ResSupportV3.V3.Infrastructure.Migrations
+{
+    public partial class AddCallerToCallsTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "caller",
+                table: "help_request_calls",
+                type: "character varying",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "caller",
+                table: "help_request_calls");
+        }
+    }
+}

--- a/cv19ResSupportV3/V3/Infrastructure/Migrations/20201130094240_ChangeCallerToCallHandler.Designer.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/Migrations/20201130094240_ChangeCallerToCallHandler.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using cv19ResSupportV3.V3.Infrastructure;
@@ -9,9 +10,10 @@ using cv19ResSupportV3.V3.Infrastructure;
 namespace cv19ResSupportV3.V3.Infrastructure.Migrations
 {
     [DbContext(typeof(HelpRequestsContext))]
-    partial class HelpRequestsContextModelSnapshot : ModelSnapshot
+    [Migration("20201130094240_ChangeCallerToCallHandler")]
+    partial class ChangeCallerToCallHandler
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -43,8 +45,8 @@ namespace cv19ResSupportV3.V3.Infrastructure.Migrations
                         .HasColumnName("call_type")
                         .HasColumnType("character varying");
 
-                    b.Property<string>("CallHandler")
-                        .HasColumnName("call_handler")
+                    b.Property<string>("Caller")
+                        .HasColumnName("caller")
                         .HasColumnType("character varying");
 
                     b.Property<int>("HelpRequestId")

--- a/cv19ResSupportV3/V3/Infrastructure/Migrations/20201130094240_ChangeCallerToCallHandler.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/Migrations/20201130094240_ChangeCallerToCallHandler.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace cv19ResSupportV3.V3.Infrastructure.Migrations
+{
+    public partial class ChangeCallerToCallHandler : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "caller",
+                table: "help_request_calls",
+                newName: "call_handler");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "call_handler",
+                table: "help_request_calls",
+                newName: "caller");
+        }
+    }
+}


### PR DESCRIPTION
# What
- Add migration to rename caller to call handler

# Why
- The caller can be the resident if its an inbound call, so a more appropriate name is call handler

# Screenshots
N/A

# Link to ticket
https://trello.com/c/rtLti48Q/107-add-call-handler-name-to-call-on-api-and-frontend-call-log

# Notes
N/A

