### PR TITLE
Add Nhs Ctsas Id

### DIFF
--- a/cv19ResSupportV3/V3/Boundary/Response/HelpRequestGetResponse.cs
+++ b/cv19ResSupportV3/V3/Boundary/Response/HelpRequestGetResponse.cs
@@ -63,6 +63,8 @@ namespace cv19ResSupportV3.V3.Boundary.Response
         public string CaseNotes { get; set; }
         public string AdviceNotes { get; set; }
         public string HelpNeeded { get; set; }
+
+        public string NhsCtasId { get; set; }
         public List<HelpRequestCall> HelpRequestCalls { get; set; }
     }
 }

--- a/cv19ResSupportV3/V3/Domain/HelpRequest.cs
+++ b/cv19ResSupportV3/V3/Domain/HelpRequest.cs
@@ -61,5 +61,6 @@ namespace cv19ResSupportV3.V3.Domain
         public string CaseNotes { get; set; }
         public string AdviceNotes { get; set; }
         public string HelpNeeded { get; set; }
+        public string NhsCtasId { get; set; }
     }
 }

--- a/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
@@ -68,7 +68,8 @@ namespace cv19ResSupportV3.V3.Factories
                 InitialCallbackCompleted = helpRequestEntity.InitialCallbackCompleted,
                 CaseNotes = helpRequestEntity.CaseNotes,
                 AdviceNotes = helpRequestEntity.AdviceNotes,
-                HelpNeeded = helpRequestEntity.HelpNeeded
+                HelpNeeded = helpRequestEntity.HelpNeeded,
+                NhsCtasId = helpRequestEntity.NhsCtasId
             };
         }
 
@@ -132,7 +133,8 @@ namespace cv19ResSupportV3.V3.Factories
                 InitialCallbackCompleted = helpRequest.InitialCallbackCompleted,
                 CaseNotes = helpRequest.CaseNotes,
                 AdviceNotes = helpRequest.AdviceNotes,
-                HelpNeeded = helpRequest.HelpNeeded
+                HelpNeeded = helpRequest.HelpNeeded,
+                NhsCtasId = helpRequest.NhsCtasId
             };
         }
 

--- a/cv19ResSupportV3/V3/Factories/ResponseFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/ResponseFactory.cs
@@ -73,6 +73,7 @@ namespace cv19ResSupportV3.V3.Factories
                 CaseNotes = hr.CaseNotes,
                 AdviceNotes = hr.AdviceNotes,
                 HelpNeeded = hr.HelpNeeded,
+                NhsCtasId = hr.NhsCtasId,
                 HelpRequestCalls = hr.HelpRequestCalls.ToDomain()
             };
         }

--- a/cv19ResSupportV3/V3/Infrastructure/HelpRequestEntity.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/HelpRequestEntity.cs
@@ -184,6 +184,9 @@ namespace cv19ResSupportV3.V3.Infrastructure
         [Column("help_needed")]
         public string HelpNeeded { get; set; }
 
+        [Column("nhs_ctas_id")]
+        public string NhsCtasId { get; set; }
+
         public List<HelpRequestCallEntity> HelpRequestCalls { get; set; }
     }
 }

--- a/cv19ResSupportV3/V3/Infrastructure/HelpRequestsContext.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/HelpRequestsContext.cs
@@ -188,6 +188,9 @@ namespace cv19ResSupportV3.V3.Infrastructure
                         entity.Property(e => e.HelpNeeded)
                             .HasColumnName("help_needed")
                             .HasColumnType("character varying");
+                        entity.Property(e => e.NhsCtasId)
+                            .HasColumnName("nhs_ctas_id")
+                            .HasColumnType("character varying");
                     }
                 );
 

--- a/cv19ResSupportV3/V3/Infrastructure/Migrations/20201202103831_AddNhsCtasId.Designer.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/Migrations/20201202103831_AddNhsCtasId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using cv19ResSupportV3.V3.Infrastructure;
@@ -9,9 +10,10 @@ using cv19ResSupportV3.V3.Infrastructure;
 namespace cv19ResSupportV3.V3.Infrastructure.Migrations
 {
     [DbContext(typeof(HelpRequestsContext))]
-    partial class HelpRequestsContextModelSnapshot : ModelSnapshot
+    [Migration("20201202103831_AddNhsCtasId")]
+    partial class AddNhsCtasId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/cv19ResSupportV3/V3/Infrastructure/Migrations/20201202103831_AddNhsCtasId.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/Migrations/20201202103831_AddNhsCtasId.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace cv19ResSupportV3.V3.Infrastructure.Migrations
+{
+    public partial class AddNhsCtasId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "nhs_ctas_id",
+                table: "i_need_help_resident_support_v3",
+                type: "character varying",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "nhs_ctas_id",
+                table: "i_need_help_resident_support_v3");
+        }
+    }
+}


### PR DESCRIPTION
# What
- Add nhs ctas id to api and db

# Why
- Call handlers need this to complete CTAS form for contact tracing

# Screenshots
n/a

# Link to ticket
https://trello.com/c/PBmmLNBl/118-as-a-outbound-call-handler-when-i-view-a-help-request-then-i-can-see-the-nhs-test-and-trace-ctas-number-numbers

# Notes


