### PR TITLE
Fix/create help request use boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ tmp/
 
 .fake
 .ionide
+/dotnet-format-local/*

--- a/cv19ResSupportV3.Tests/V3/Controllers/HelpRequestControllerTests.cs
+++ b/cv19ResSupportV3.Tests/V3/Controllers/HelpRequestControllerTests.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using AutoFixture;
 using cv19ResSupportV3.V3.Boundary.Response;
+using cv19ResSupportV3.V3.Boundary.Requests;
 using cv19ResSupportV3.V3.Controllers;
 using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Factories;
 using cv19ResSupportV3.V3.UseCase;
 using cv19ResSupportV3.V3.UseCase.Interfaces;
 using FluentAssertions;
@@ -40,8 +42,8 @@ namespace cv19ResRupportV3.Tests.V3.Controllers
         [Test]
         public void ReturnsResponseWithStatus()
         {
-            var request = new Fixture().Build<HelpRequest>().Create();
-            _fakeCreateHelpRequestUseCase.Setup(x => x.Execute(request))
+            var request = new Fixture().Build<HelpRequestCreateRequestBoundary>().Create();
+            _fakeCreateHelpRequestUseCase.Setup(x => x.Execute(It.Is<HelpRequest>(o => o.Id == request.Id)))
                 .Returns(new HelpRequestCreateResponse() { Id = request.Id });
             var response = _classUnderTest.CreateHelpRequest(request) as CreatedResult;
             response.StatusCode.Should().Be(201);

--- a/cv19ResSupportV3.Tests/V3/Controllers/HelpRequestControllerTests.cs
+++ b/cv19ResSupportV3.Tests/V3/Controllers/HelpRequestControllerTests.cs
@@ -44,7 +44,7 @@ namespace cv19ResRupportV3.Tests.V3.Controllers
         {
             var request = new Fixture().Build<HelpRequestCreateRequestBoundary>().Create();
             _fakeCreateHelpRequestUseCase.Setup(x => x.Execute(It.Is<HelpRequest>(o => o.Id == request.Id)))
-                .Returns(new HelpRequestCreateResponse() { Id = request.Id });
+                .Returns(request.Id);
             var response = _classUnderTest.CreateHelpRequest(request) as CreatedResult;
             response.StatusCode.Should().Be(201);
         }

--- a/cv19ResSupportV3.Tests/V3/E2ETests/CreateHelpRequest.cs
+++ b/cv19ResSupportV3.Tests/V3/E2ETests/CreateHelpRequest.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using AutoFixture;
 using cv19ResSupportV3.V3.Boundary.Response;
+using cv19ResSupportV3.V3.Boundary.Requests;
 using cv19ResSupportV3.V3.Domain;
 using FluentAssertions;
 using Newtonsoft.Json;
@@ -18,7 +19,7 @@ namespace cv19ResSupportV3.Tests.V3.E2ETests
         public async Task GetResidentInformationByIdReturnsTheCorrectInformation()
         {
             DatabaseContext.Database.RollbackTransaction();
-            var requestObject = new Fixture().Build<HelpRequest>().Create();
+            var requestObject = new Fixture().Build<HelpRequestCreateRequestBoundary>().Create();
             var data = JsonConvert.SerializeObject(requestObject);
             HttpContent postContent = new StringContent(data, Encoding.UTF8, "application/json");
             var uri = new Uri($"api/v3/help-requests", UriKind.Relative);

--- a/cv19ResSupportV3.Tests/V3/UseCase/CreateHelpRequestUseCaseTests.cs
+++ b/cv19ResSupportV3.Tests/V3/UseCase/CreateHelpRequestUseCaseTests.cs
@@ -26,14 +26,10 @@ namespace cv19ResSupportV3.Tests.V3.UseCase
         [Test]
         public void ExecuteSavesRequestToDatabase()
         {
-            var expectedResponse = new HelpRequestCreateResponse
-            {
-                Id = 1
-            };
             _mockGateway.Setup(s => s.CreateHelpRequest(It.IsAny<HelpRequestEntity>())).Returns(1);
             var dataToSave = new Fixture().Build<HelpRequest>().Create();
             var response = _classUnderTest.Execute(dataToSave);
-            response.Should().BeEquivalentTo(expectedResponse);
+            response.Should().Be(1);
         }
     }
 }

--- a/cv19ResSupportV3/V3/Boundary/Requests/HelpRequestCreateRequestBoundary.cs
+++ b/cv19ResSupportV3/V3/Boundary/Requests/HelpRequestCreateRequestBoundary.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace cv19ResSupportV3.V3.Boundary.Requests
+{
+    public class HelpRequestCreateRequestBoundary
+    {
+        public int Id { get; set; }
+        public bool? IsOnBehalf { get; set; }
+        public bool? ConsentToCompleteOnBehalf { get; set; }
+        public string OnBehalfFirstName { get; set; }
+        public string OnBehalfLastName { get; set; }
+        public string OnBehalfEmailAddress { get; set; }
+        public string OnBehalfContactNumber { get; set; }
+        public string RelationshipWithResident { get; set; }
+        public string PostCode { get; set; }
+        public string Uprn { get; set; }
+        public string Ward { get; set; }
+        public string AddressFirstLine { get; set; }
+        public string AddressSecondLine { get; set; }
+        public string AddressThirdLine { get; set; }
+        public string GettingInTouchReason { get; set; }
+        public bool? HelpWithAccessingFood { get; set; }
+        public bool? HelpWithAccessingSupermarketFood { get; set; }
+        public bool? HelpWithCompletingNssForm { get; set; }
+        public bool? HelpWithShieldingGuidance { get; set; }
+        public bool? HelpWithNoNeedsIdentified { get; set; }
+        public bool? HelpWithAccessingMedicine { get; set; }
+        public bool? HelpWithAccessingOtherEssentials { get; set; }
+        public bool? HelpWithDebtAndMoney { get; set; }
+        public bool? HelpWithHealth { get; set; }
+        public bool? HelpWithMentalHealth { get; set; }
+        public bool? HelpWithAccessingInternet { get; set; }
+        public bool? HelpWithHousing { get; set; }
+        public bool? HelpWithJobsOrTraining { get; set; }
+        public bool? HelpWithChildrenAndSchools { get; set; }
+        public bool? HelpWithDisabilities { get; set; }
+        public bool? HelpWithSomethingElse { get; set; }
+        public bool? MedicineDeliveryHelpNeeded { get; set; }
+        public bool? IsPharmacistAbleToDeliver { get; set; }
+        public string WhenIsMedicinesDelivered { get; set; }
+        public string NameAddressPharmacist { get; set; }
+        public string UrgentEssentials { get; set; }
+        public string UrgentEssentialsAnythingElse { get; set; }
+        public string CurrentSupport { get; set; }
+        public string CurrentSupportFeedback { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string DobMonth { get; set; }
+        public string DobYear { get; set; }
+        public string DobDay { get; set; }
+        public string ContactTelephoneNumber { get; set; }
+        public string ContactMobileNumber { get; set; }
+        public string EmailAddress { get; set; }
+        public string GpSurgeryDetails { get; set; }
+        public string NumberOfChildrenUnder18 { get; set; }
+        public bool? ConsentToShare { get; set; }
+        public DateTime? DateTimeRecorded { get; set; }
+        public string RecordStatus { get; set; }
+        public bool? InitialCallbackCompleted { get; set; }
+        public bool? CallbackRequired { get; set; }
+        public string CaseNotes { get; set; }
+        public string AdviceNotes { get; set; }
+        public string HelpNeeded { get; set; }
+        public string NhsNumber { get; set; }
+        public string NhsCtasId { get; set; }
+    }
+}

--- a/cv19ResSupportV3/V3/Controllers/HelpRequestsController.cs
+++ b/cv19ResSupportV3/V3/Controllers/HelpRequestsController.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using cv19ResSupportV3.V3.Boundary.Requests;
 using cv19ResSupportV3.V3.Boundary.Response;
 using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Factories;
 using cv19ResSupportV3.V3.UseCase;
 using cv19ResSupportV3.V3.UseCase.Interfaces;
 using Microsoft.AspNetCore.Http;
@@ -39,11 +40,12 @@ namespace cv19ResSupportV3.V3.Controllers
         /// <response code="201">...</response>
         [ProducesResponseType(typeof(HelpRequestCreateResponse), StatusCodes.Status201Created)]
         [HttpPost]
-        public IActionResult CreateHelpRequest(HelpRequest request)
+        public IActionResult CreateHelpRequest(HelpRequestCreateRequestBoundary request)
         {
             try
             {
-                var result = _createHelpRequestUseCase.Execute(request);
+                var domain = request.ToDomain();
+                var result = _createHelpRequestUseCase.Execute(domain);
                 return Created(new Uri($"api/v3/help-requests/{result.Id}", UriKind.Relative), result);
             }
             catch (Exception e)

--- a/cv19ResSupportV3/V3/Controllers/HelpRequestsController.cs
+++ b/cv19ResSupportV3/V3/Controllers/HelpRequestsController.cs
@@ -45,8 +45,9 @@ namespace cv19ResSupportV3.V3.Controllers
             try
             {
                 var domain = request.ToDomain();
-                var result = _createHelpRequestUseCase.Execute(domain);
-                return Created(new Uri($"api/v3/help-requests/{result.Id}", UriKind.Relative), result);
+                var id = _createHelpRequestUseCase.Execute(domain);
+                var result = new HelpRequestCreateResponse() { Id = id };
+                return Created(new Uri($"api/v3/help-requests/{id}", UriKind.Relative), result);
             }
             catch (Exception e)
             {

--- a/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using cv19ResSupportV3.V3.Boundary.Requests;
 using cv19ResSupportV3.V3.Infrastructure;
 using HelpRequest = cv19ResSupportV3.V3.Domain.HelpRequest;
 using HelpRequestCall = cv19ResSupportV3.V3.Domain.HelpRequestCall;
@@ -9,6 +10,72 @@ namespace cv19ResSupportV3.V3.Factories
     public static class EntityFactory
     {
         public static HelpRequest ToDomain(this HelpRequestEntity helpRequestEntity)
+        {
+            return new HelpRequest()
+            {
+                Id = helpRequestEntity.Id,
+                IsOnBehalf = helpRequestEntity.IsOnBehalf,
+                ConsentToCompleteOnBehalf = helpRequestEntity.ConsentToCompleteOnBehalf,
+                OnBehalfFirstName = helpRequestEntity.OnBehalfFirstName,
+                OnBehalfLastName = helpRequestEntity.OnBehalfLastName,
+                OnBehalfEmailAddress = helpRequestEntity.OnBehalfEmailAddress,
+                OnBehalfContactNumber = helpRequestEntity.OnBehalfContactNumber,
+                RelationshipWithResident = helpRequestEntity.RelationshipWithResident,
+                PostCode = helpRequestEntity.PostCode,
+                Uprn = helpRequestEntity.Uprn,
+                Ward = helpRequestEntity.Ward,
+                AddressFirstLine = helpRequestEntity.AddressFirstLine,
+                AddressSecondLine = helpRequestEntity.AddressSecondLine,
+                AddressThirdLine = helpRequestEntity.AddressThirdLine,
+                GettingInTouchReason = helpRequestEntity.GettingInTouchReason,
+                HelpWithAccessingFood = helpRequestEntity.HelpWithAccessingFood,
+                HelpWithAccessingSupermarketFood = helpRequestEntity.HelpWithAccessingSupermarketFood,
+                HelpWithCompletingNssForm = helpRequestEntity.HelpWithCompletingNssForm,
+                HelpWithShieldingGuidance = helpRequestEntity.HelpWithShieldingGuidance,
+                HelpWithNoNeedsIdentified = helpRequestEntity.HelpWithNoNeedsIdentified,
+                HelpWithAccessingMedicine = helpRequestEntity.HelpWithAccessingMedicine,
+                HelpWithAccessingOtherEssentials = helpRequestEntity.HelpWithAccessingOtherEssentials,
+                HelpWithDebtAndMoney = helpRequestEntity.HelpWithDebtAndMoney,
+                HelpWithHealth = helpRequestEntity.HelpWithHealth,
+                HelpWithMentalHealth = helpRequestEntity.HelpWithMentalHealth,
+                HelpWithAccessingInternet = helpRequestEntity.HelpWithAccessingInternet,
+                HelpWithHousing = helpRequestEntity.HelpWithHousing,
+                HelpWithJobsOrTraining = helpRequestEntity.HelpWithJobsOrTraining,
+                HelpWithChildrenAndSchools = helpRequestEntity.HelpWithChildrenAndSchools,
+                HelpWithDisabilities = helpRequestEntity.HelpWithDisabilities,
+                HelpWithSomethingElse = helpRequestEntity.HelpWithSomethingElse,
+                MedicineDeliveryHelpNeeded = helpRequestEntity.MedicineDeliveryHelpNeeded,
+                IsPharmacistAbleToDeliver = helpRequestEntity.IsPharmacistAbleToDeliver,
+                WhenIsMedicinesDelivered = helpRequestEntity.WhenIsMedicinesDelivered,
+                NameAddressPharmacist = helpRequestEntity.NameAddressPharmacist,
+                UrgentEssentials = helpRequestEntity.UrgentEssentials,
+                UrgentEssentialsAnythingElse = helpRequestEntity.UrgentEssentialsAnythingElse,
+                CurrentSupport = helpRequestEntity.CurrentSupport,
+                CurrentSupportFeedback = helpRequestEntity.CurrentSupportFeedback,
+                FirstName = helpRequestEntity.FirstName,
+                LastName = helpRequestEntity.LastName,
+                DobMonth = helpRequestEntity.DobMonth,
+                DobYear = helpRequestEntity.DobYear,
+                DobDay = helpRequestEntity.DobDay,
+                ContactTelephoneNumber = helpRequestEntity.ContactTelephoneNumber,
+                ContactMobileNumber = helpRequestEntity.ContactMobileNumber,
+                EmailAddress = helpRequestEntity.EmailAddress,
+                GpSurgeryDetails = helpRequestEntity.GpSurgeryDetails,
+                NumberOfChildrenUnder18 = helpRequestEntity.NumberOfChildrenUnder18,
+                ConsentToShare = helpRequestEntity.ConsentToShare,
+                DateTimeRecorded = helpRequestEntity.DateTimeRecorded,
+                RecordStatus = helpRequestEntity.RecordStatus,
+                CallbackRequired = helpRequestEntity.CallbackRequired,
+                InitialCallbackCompleted = helpRequestEntity.InitialCallbackCompleted,
+                CaseNotes = helpRequestEntity.CaseNotes,
+                AdviceNotes = helpRequestEntity.AdviceNotes,
+                HelpNeeded = helpRequestEntity.HelpNeeded,
+                NhsNumber = helpRequestEntity.NhsNumber,
+                NhsCtasId = helpRequestEntity.NhsCtasId
+            };
+        }
+
+        public static HelpRequest ToDomain(this HelpRequestCreateRequestBoundary helpRequestEntity)
         {
             return new HelpRequest()
             {

--- a/cv19ResSupportV3/V3/UseCase/CreateHelpRequestUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/CreateHelpRequestUseCase.cs
@@ -13,13 +13,10 @@ namespace cv19ResSupportV3.V3.UseCase
         {
             _gateway = gateway;
         }
-        public HelpRequestCreateResponse Execute(HelpRequest request)
+        public int Execute(HelpRequest request)
         {
             var response = _gateway.CreateHelpRequest(request.ToEntity());
-            return new HelpRequestCreateResponse
-            {
-                Id = response
-            };
+            return response;
         }
     }
 }

--- a/cv19ResSupportV3/V3/UseCase/Interfaces/ICreateHelpRequestUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/Interfaces/ICreateHelpRequestUseCase.cs
@@ -5,6 +5,6 @@ namespace cv19ResSupportV3.V3.UseCase.Interfaces
 {
     public interface ICreateHelpRequestUseCase
     {
-        HelpRequestCreateResponse Execute(HelpRequest request);
+        int Execute(HelpRequest request);
     }
 }


### PR DESCRIPTION
# What
Move the responsibility out of the boundary layer and into presentation layer 

# Why
To enable remodelling of the API internals and the database without changing what the presentation layer is returning

# Link to ticket
https://trello.com/c/UnCuYcQV/183-introduce-a-boundary-object-for-the-help-request-create-endpoint-so-we-can-remodel-the-domain-object-without-the-api-changing

# Notes


