### PR TITLE
Add script to publish API doc to Swaggerhub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,7 @@ lint:
 	-dotnet tool install -g dotnet-format
 	dotnet tool update -g dotnet-format
 	dotnet format
+
+.PHONY: publish-to-swagger-hub
+publish-to-swagger-hub:
+	cv19ResSupportV3/publish-to-swagger-hub

--- a/cv19ResSupportV3/.config/dotnet-tools.json
+++ b/cv19ResSupportV3/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "swashbuckle.aspnetcore.cli": {
+      "version": "5.6.2",
+      "commands": [
+        "swagger"
+      ]
+    }
+  }
+}

--- a/cv19ResSupportV3/cv19ResSupportV3.csproj
+++ b/cv19ResSupportV3/cv19ResSupportV3.csproj
@@ -18,10 +18,10 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.4.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.6.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.6.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.6.3" />
   </ItemGroup>
 
 </Project>

--- a/cv19ResSupportV3/publish-to-swagger-hub
+++ b/cv19ResSupportV3/publish-to-swagger-hub
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Exit on any failure
+set -e
+
+if [ -z "$SWAGGERHUB_API_KEY" ]
+then
+    echo "You must configure SWAGGERHUB_API_KEY"
+    exit 1
+fi
+
+if [ ! -x "$(command -v npm)" ]
+then
+    echo "Node must be installed"
+    exit 1
+fi
+
+if [ ! -x "$(command -v swaggerhub)" ]
+then
+    echo "Installing swaggerhub-cli"
+    npm i -g --silent swaggerhub-cli
+fi
+
+owner="Hackney"
+api_name="here-to-help"
+api_version="v3.0"
+
+if [ "$1" = "production"  ]
+then
+    swagger_version="$api_version"
+    echo "Stage is production, therefore will name this version '${swagger_version}'"
+else
+    suffix="$(git branch --show-current)"
+    # The following suffix interpolation replaces forward slashes with underscores
+    swagger_version="${api_version}-${suffix//\//_}"
+    echo "Stage is not production, therefore will name this version after the branch. ${swagger_version}"
+fi
+
+tmp_dir="$(mktemp -d)"
+json_file="${tmp_dir}/swagger.json"
+
+(
+cd cv19ResSupportV3
+dotnet tool restore
+
+dotnet build -c Release -o out
+dotnet swagger tofile --output "${json_file}" ./out/cv19ResSupportV3.dll "${api_version}"
+)
+
+swagger_path="${owner}/${api_name}/${swagger_version}"
+
+if [ -z "$(swaggerhub api:get "${swagger_path}")" ]
+then
+    swaggerhub api:create "$swagger_path" --file "${json_file}"
+else
+    swaggerhub api:update "$swagger_path" --file "${json_file}"
+fi
+
+echo "Cleaning up ${tmp_dir}"
+rm -rf "$tmp_dir"


### PR DESCRIPTION
# What

Introduce a script that can generate the OpenAPI documentation, via Swashbuckle and upload the documentation into Swaggerhub.

You can run the script yourself simply by running `make publish-swagger-doc`. When run it will determine which stage it is being run at, in all cases except production it will create (or update) a swagger API version based on the current version (v3.0) and the branch name.

For example, on this branch it will read `v3.0-publish-api-doc-to-swaggerhub`.

This can then be shared with others during review to ensure the API design is sane. For example, you can see the API doc generated for this branch here: https://app.swaggerhub.com/apis/Hackney/here-to-help/v3.0-publish-api-doc-to-swaggerhub

# Why

We have the ability to generate API documentation based on code, we should be taking advantage of that at all times, rather than duplicating effort by handcrafting a yaml file in swaggerhub.

By using the generation, we shortern the feedback loop. 

# Screenshots


# Link to ticket
https://trello.com/c/y3DKuWPH/81-add-api-documentation

# Notes

* Currently this is not integrated into the CI pipeline, it would ideally update v3.0 when production is deployed, v3.0-development when development is deployed etc.
* The API doc is generated within the dotnet environment on the machine you're using, not within docker. This is something we can address later but not sure the value of that right now

