### PR TITLE
Add boundaries

### DIFF
--- a/cv19ResSupportV3/V3/Boundary/Requests/HelpRequestPatchRequest.cs
+++ b/cv19ResSupportV3/V3/Boundary/Requests/HelpRequestPatchRequest.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace cv19ResSupportV3.V3.Boundary.Requests
+{
+    public class HelpRequestPatchRequest
+    {
+        public string PostCode { get; set; }
+        public string Uprn { get; set; }
+        public string Ward { get; set; }
+        public string AddressFirstLine { get; set; }
+        public string AddressSecondLine { get; set; }
+        public string AddressThirdLine { get; set; }
+        public string GettingInTouchReason { get; set; }
+        public bool? HelpWithAccessingFood { get; set; }
+        public bool? HelpWithAccessingSupermarketFood { get; set; }
+        public bool? HelpWithCompletingNssForm { get; set; }
+        public bool? HelpWithShieldingGuidance { get; set; }
+        public bool? HelpWithNoNeedsIdentified { get; set; }
+        public bool? HelpWithAccessingMedicine { get; set; }
+        public bool? HelpWithAccessingOtherEssentials { get; set; }
+        public bool? HelpWithDebtAndMoney { get; set; }
+        public bool? HelpWithHealth { get; set; }
+        public bool? HelpWithMentalHealth { get; set; }
+        public bool? HelpWithAccessingInternet { get; set; }
+        public bool? HelpWithSomethingElse { get; set; }
+        public string CurrentSupport { get; set; }
+        public string CurrentSupportFeedback { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string DobMonth { get; set; }
+        public string DobYear { get; set; }
+        public string DobDay { get; set; }
+        public string ContactTelephoneNumber { get; set; }
+        public string ContactMobileNumber { get; set; }
+        public string EmailAddress { get; set; }
+        public string GpSurgeryDetails { get; set; }
+        public string NumberOfChildrenUnder18 { get; set; }
+        public bool? ConsentToShare { get; set; }
+        public DateTime? DateTimeRecorded { get; set; }
+        public string RecordStatus { get; set; }
+        public bool? InitialCallbackCompleted { get; set; }
+        public bool? CallbackRequired { get; set; }
+        public string CaseNotes { get; set; }
+        public string AdviceNotes { get; set; }
+        public string HelpNeeded { get; set; }
+    }
+}

--- a/cv19ResSupportV3/V3/Boundary/Requests/HelpRequestUpdateRequest.cs
+++ b/cv19ResSupportV3/V3/Boundary/Requests/HelpRequestUpdateRequest.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace cv19ResSupportV3.V3.Boundary.Requests
+{
+    public class HelpRequestUpdateRequest
+    {
+        public int Id { get; set; }
+        public bool? IsOnBehalf { get; set; }
+        public bool? ConsentToCompleteOnBehalf { get; set; }
+        public string OnBehalfFirstName { get; set; }
+        public string OnBehalfLastName { get; set; }
+        public string OnBehalfEmailAddress { get; set; }
+        public string OnBehalfContactNumber { get; set; }
+        public string RelationshipWithResident { get; set; }
+        public string PostCode { get; set; }
+        public string Uprn { get; set; }
+        public string Ward { get; set; }
+        public string AddressFirstLine { get; set; }
+        public string AddressSecondLine { get; set; }
+        public string AddressThirdLine { get; set; }
+        public string GettingInTouchReason { get; set; }
+        public bool? HelpWithAccessingFood { get; set; }
+        public bool? HelpWithAccessingSupermarketFood { get; set; }
+        public bool? HelpWithCompletingNssForm { get; set; }
+        public bool? HelpWithShieldingGuidance { get; set; }
+        public bool? HelpWithNoNeedsIdentified { get; set; }
+        public bool? HelpWithAccessingMedicine { get; set; }
+        public bool? HelpWithAccessingOtherEssentials { get; set; }
+        public bool? HelpWithDebtAndMoney { get; set; }
+        public bool? HelpWithHealth { get; set; }
+        public bool? HelpWithMentalHealth { get; set; }
+        public bool? HelpWithAccessingInternet { get; set; }
+        public bool? HelpWithHousing { get; set; }
+        public bool? HelpWithJobsOrTraining { get; set; }
+        public bool? HelpWithChildrenAndSchools { get; set; }
+        public bool? HelpWithDisabilities { get; set; }
+        public bool? HelpWithSomethingElse { get; set; }
+        public bool? MedicineDeliveryHelpNeeded { get; set; }
+        public bool? IsPharmacistAbleToDeliver { get; set; }
+        public string WhenIsMedicinesDelivered { get; set; }
+        public string NameAddressPharmacist { get; set; }
+        public string UrgentEssentials { get; set; }
+        public string UrgentEssentialsAnythingElse { get; set; }
+        public string CurrentSupport { get; set; }
+        public string CurrentSupportFeedback { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string DobMonth { get; set; }
+        public string DobYear { get; set; }
+        public string DobDay { get; set; }
+        public string ContactTelephoneNumber { get; set; }
+        public string ContactMobileNumber { get; set; }
+        public string EmailAddress { get; set; }
+        public string GpSurgeryDetails { get; set; }
+        public string NumberOfChildrenUnder18 { get; set; }
+        public bool? ConsentToShare { get; set; }
+        public DateTime? DateTimeRecorded { get; set; }
+        public string RecordStatus { get; set; }
+        public bool? InitialCallbackCompleted { get; set; }
+        public bool? CallbackRequired { get; set; }
+        public string CaseNotes { get; set; }
+        public string AdviceNotes { get; set; }
+        public string HelpNeeded { get; set; }
+        public string NhsNumber { get; set; }
+        public string NhsCtasId { get; set; }
+    }
+}

--- a/cv19ResSupportV3/V3/Boundary/Response/HelpRequestUpdateResponse.cs
+++ b/cv19ResSupportV3/V3/Boundary/Response/HelpRequestUpdateResponse.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace cv19ResSupportV3.V3.Boundary.Response
+{
+    public class HelpRequestUpdateResponse
+    {
+        public int Id { get; set; }
+        public bool? IsOnBehalf { get; set; }
+        public bool? ConsentToCompleteOnBehalf { get; set; }
+        public string OnBehalfFirstName { get; set; }
+        public string OnBehalfLastName { get; set; }
+        public string OnBehalfEmailAddress { get; set; }
+        public string OnBehalfContactNumber { get; set; }
+        public string RelationshipWithResident { get; set; }
+        public string PostCode { get; set; }
+        public string Uprn { get; set; }
+        public string Ward { get; set; }
+        public string AddressFirstLine { get; set; }
+        public string AddressSecondLine { get; set; }
+        public string AddressThirdLine { get; set; }
+        public string GettingInTouchReason { get; set; }
+        public bool? HelpWithAccessingFood { get; set; }
+        public bool? HelpWithAccessingSupermarketFood { get; set; }
+        public bool? HelpWithCompletingNssForm { get; set; }
+        public bool? HelpWithShieldingGuidance { get; set; }
+        public bool? HelpWithNoNeedsIdentified { get; set; }
+        public bool? HelpWithAccessingMedicine { get; set; }
+        public bool? HelpWithAccessingOtherEssentials { get; set; }
+        public bool? HelpWithDebtAndMoney { get; set; }
+        public bool? HelpWithHealth { get; set; }
+        public bool? HelpWithMentalHealth { get; set; }
+        public bool? HelpWithAccessingInternet { get; set; }
+        public bool? HelpWithHousing { get; set; }
+        public bool? HelpWithJobsOrTraining { get; set; }
+        public bool? HelpWithChildrenAndSchools { get; set; }
+        public bool? HelpWithDisabilities { get; set; }
+        public bool? HelpWithSomethingElse { get; set; }
+        public bool? MedicineDeliveryHelpNeeded { get; set; }
+        public bool? IsPharmacistAbleToDeliver { get; set; }
+        public string WhenIsMedicinesDelivered { get; set; }
+        public string NameAddressPharmacist { get; set; }
+        public string UrgentEssentials { get; set; }
+        public string UrgentEssentialsAnythingElse { get; set; }
+        public string CurrentSupport { get; set; }
+        public string CurrentSupportFeedback { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string DobMonth { get; set; }
+        public string DobYear { get; set; }
+        public string DobDay { get; set; }
+        public string ContactTelephoneNumber { get; set; }
+        public string ContactMobileNumber { get; set; }
+        public string EmailAddress { get; set; }
+        public string GpSurgeryDetails { get; set; }
+        public string NumberOfChildrenUnder18 { get; set; }
+        public bool? ConsentToShare { get; set; }
+        public DateTime? DateTimeRecorded { get; set; }
+        public string RecordStatus { get; set; }
+        public bool? InitialCallbackCompleted { get; set; }
+        public bool? CallbackRequired { get; set; }
+        public string CaseNotes { get; set; }
+        public string AdviceNotes { get; set; }
+        public string HelpNeeded { get; set; }
+        public string NhsNumber { get; set; }
+        public string NhsCtasId { get; set; }
+    }
+}

--- a/cv19ResSupportV3/V3/Controllers/HelpRequestsController.cs
+++ b/cv19ResSupportV3/V3/Controllers/HelpRequestsController.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using cv19ResSupportV3.V3.Boundary.Requests;
 using cv19ResSupportV3.V3.Boundary.Response;
-using cv19ResSupportV3.V3.Domain;
 using cv19ResSupportV3.V3.Factories;
 using cv19ResSupportV3.V3.UseCase;
 using cv19ResSupportV3.V3.UseCase.Interfaces;
@@ -109,11 +108,12 @@ namespace cv19ResSupportV3.V3.Controllers
         /// <response code="400">There was an issue updating the record.</response>
         [HttpPatch]
         [Route("{id}")]
-        public IActionResult PatchHelpRequest([FromRoute] int id, [FromBody] HelpRequest request)
+        public IActionResult PatchHelpRequest([FromRoute] int id, [FromBody] HelpRequestPatchRequest request)
         {
             try
             {
-                _patchHelpRequestUseCase.Execute(id, request);
+                var domain = request.ToDomain();
+                _patchHelpRequestUseCase.Execute(id, domain);
                 return Ok();
             }
             catch (Exception e)
@@ -141,7 +141,7 @@ namespace cv19ResSupportV3.V3.Controllers
         /// </summary>
         /// <response code="200">Record retrieved successfully</response>
         /// <response code="404">A record with the specified id was not found</response>
-        [ProducesResponseType(typeof(HelpRequest), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(HelpRequestGetResponse), StatusCodes.Status200OK)]
         [HttpGet]
         [Route("{id}")]
         public IActionResult GetHelpRequest(int id)

--- a/cv19ResSupportV3/V3/Controllers/HelpRequestsController.cs
+++ b/cv19ResSupportV3/V3/Controllers/HelpRequestsController.cs
@@ -60,13 +60,15 @@ namespace cv19ResSupportV3.V3.Controllers
         /// </summary>
         /// <response code="200">The record has been updated</response>
         /// <response code="400">There was an issue updating the record.</response>
-        [ProducesResponseType(typeof(HelpRequestCreateResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(HelpRequestUpdateResponse), StatusCodes.Status200OK)]
         [HttpPut]
-        public IActionResult UpdateHelpRequest(HelpRequest request)
+        public IActionResult UpdateHelpRequest(HelpRequestUpdateRequest request)
         {
             try
             {
-                var result = _updateHelpRequestUseCase.Execute(request);
+                var domain = request.ToDomain();
+                var response = _updateHelpRequestUseCase.Execute(domain);
+                var result = response.ToResponse();
                 return Ok(result);
             }
             catch (Exception e)

--- a/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
@@ -207,7 +207,73 @@ namespace cv19ResSupportV3.V3.Factories
             };
         }
 
-        public static HelpRequestCallEntity ToEntity(this HelpRequestCall helpRequestCall)
+         public static HelpRequest ToDomain(this HelpRequestUpdateRequest helpRequestEntity)
+        {
+            return new HelpRequest()
+            {
+                Id = helpRequestEntity.Id,
+                IsOnBehalf = helpRequestEntity.IsOnBehalf,
+                ConsentToCompleteOnBehalf = helpRequestEntity.ConsentToCompleteOnBehalf,
+                OnBehalfFirstName = helpRequestEntity.OnBehalfFirstName,
+                OnBehalfLastName = helpRequestEntity.OnBehalfLastName,
+                OnBehalfEmailAddress = helpRequestEntity.OnBehalfEmailAddress,
+                OnBehalfContactNumber = helpRequestEntity.OnBehalfContactNumber,
+                RelationshipWithResident = helpRequestEntity.RelationshipWithResident,
+                PostCode = helpRequestEntity.PostCode,
+                Uprn = helpRequestEntity.Uprn,
+                Ward = helpRequestEntity.Ward,
+                AddressFirstLine = helpRequestEntity.AddressFirstLine,
+                AddressSecondLine = helpRequestEntity.AddressSecondLine,
+                AddressThirdLine = helpRequestEntity.AddressThirdLine,
+                GettingInTouchReason = helpRequestEntity.GettingInTouchReason,
+                HelpWithAccessingFood = helpRequestEntity.HelpWithAccessingFood,
+                HelpWithAccessingSupermarketFood = helpRequestEntity.HelpWithAccessingSupermarketFood,
+                HelpWithCompletingNssForm = helpRequestEntity.HelpWithCompletingNssForm,
+                HelpWithShieldingGuidance = helpRequestEntity.HelpWithShieldingGuidance,
+                HelpWithNoNeedsIdentified = helpRequestEntity.HelpWithNoNeedsIdentified,
+                HelpWithAccessingMedicine = helpRequestEntity.HelpWithAccessingMedicine,
+                HelpWithAccessingOtherEssentials = helpRequestEntity.HelpWithAccessingOtherEssentials,
+                HelpWithDebtAndMoney = helpRequestEntity.HelpWithDebtAndMoney,
+                HelpWithHealth = helpRequestEntity.HelpWithHealth,
+                HelpWithMentalHealth = helpRequestEntity.HelpWithMentalHealth,
+                HelpWithAccessingInternet = helpRequestEntity.HelpWithAccessingInternet,
+                HelpWithHousing = helpRequestEntity.HelpWithHousing,
+                HelpWithJobsOrTraining = helpRequestEntity.HelpWithJobsOrTraining,
+                HelpWithChildrenAndSchools = helpRequestEntity.HelpWithChildrenAndSchools,
+                HelpWithDisabilities = helpRequestEntity.HelpWithDisabilities,
+                HelpWithSomethingElse = helpRequestEntity.HelpWithSomethingElse,
+                MedicineDeliveryHelpNeeded = helpRequestEntity.MedicineDeliveryHelpNeeded,
+                IsPharmacistAbleToDeliver = helpRequestEntity.IsPharmacistAbleToDeliver,
+                WhenIsMedicinesDelivered = helpRequestEntity.WhenIsMedicinesDelivered,
+                NameAddressPharmacist = helpRequestEntity.NameAddressPharmacist,
+                UrgentEssentials = helpRequestEntity.UrgentEssentials,
+                UrgentEssentialsAnythingElse = helpRequestEntity.UrgentEssentialsAnythingElse,
+                CurrentSupport = helpRequestEntity.CurrentSupport,
+                CurrentSupportFeedback = helpRequestEntity.CurrentSupportFeedback,
+                FirstName = helpRequestEntity.FirstName,
+                LastName = helpRequestEntity.LastName,
+                DobMonth = helpRequestEntity.DobMonth,
+                DobYear = helpRequestEntity.DobYear,
+                DobDay = helpRequestEntity.DobDay,
+                ContactTelephoneNumber = helpRequestEntity.ContactTelephoneNumber,
+                ContactMobileNumber = helpRequestEntity.ContactMobileNumber,
+                EmailAddress = helpRequestEntity.EmailAddress,
+                GpSurgeryDetails = helpRequestEntity.GpSurgeryDetails,
+                NumberOfChildrenUnder18 = helpRequestEntity.NumberOfChildrenUnder18,
+                ConsentToShare = helpRequestEntity.ConsentToShare,
+                DateTimeRecorded = helpRequestEntity.DateTimeRecorded,
+                RecordStatus = helpRequestEntity.RecordStatus,
+                CallbackRequired = helpRequestEntity.CallbackRequired,
+                InitialCallbackCompleted = helpRequestEntity.InitialCallbackCompleted,
+                CaseNotes = helpRequestEntity.CaseNotes,
+                AdviceNotes = helpRequestEntity.AdviceNotes,
+                HelpNeeded = helpRequestEntity.HelpNeeded,
+                NhsNumber = helpRequestEntity.NhsNumber,
+                NhsCtasId = helpRequestEntity.NhsCtasId
+            };
+        }
+
+         public static HelpRequestCallEntity ToEntity(this HelpRequestCall helpRequestCall)
         {
             return new HelpRequestCallEntity()
             {

--- a/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
@@ -273,6 +273,51 @@ namespace cv19ResSupportV3.V3.Factories
             };
         }
 
+          public static HelpRequest ToDomain(this HelpRequestPatchRequest helpRequestEntity)
+        {
+            return new HelpRequest()
+            {
+                PostCode = helpRequestEntity.PostCode,
+                Uprn = helpRequestEntity.Uprn,
+                Ward = helpRequestEntity.Ward,
+                AddressFirstLine = helpRequestEntity.AddressFirstLine,
+                AddressSecondLine = helpRequestEntity.AddressSecondLine,
+                AddressThirdLine = helpRequestEntity.AddressThirdLine,
+                GettingInTouchReason = helpRequestEntity.GettingInTouchReason,
+                HelpWithAccessingFood = helpRequestEntity.HelpWithAccessingFood,
+                HelpWithAccessingSupermarketFood = helpRequestEntity.HelpWithAccessingSupermarketFood,
+                HelpWithCompletingNssForm = helpRequestEntity.HelpWithCompletingNssForm,
+                HelpWithShieldingGuidance = helpRequestEntity.HelpWithShieldingGuidance,
+                HelpWithNoNeedsIdentified = helpRequestEntity.HelpWithNoNeedsIdentified,
+                HelpWithAccessingMedicine = helpRequestEntity.HelpWithAccessingMedicine,
+                HelpWithAccessingOtherEssentials = helpRequestEntity.HelpWithAccessingOtherEssentials,
+                HelpWithDebtAndMoney = helpRequestEntity.HelpWithDebtAndMoney,
+                HelpWithHealth = helpRequestEntity.HelpWithHealth,
+                HelpWithMentalHealth = helpRequestEntity.HelpWithMentalHealth,
+                HelpWithAccessingInternet = helpRequestEntity.HelpWithAccessingInternet,
+                CurrentSupport = helpRequestEntity.CurrentSupport,
+                CurrentSupportFeedback = helpRequestEntity.CurrentSupportFeedback,
+                FirstName = helpRequestEntity.FirstName,
+                LastName = helpRequestEntity.LastName,
+                DobMonth = helpRequestEntity.DobMonth,
+                DobYear = helpRequestEntity.DobYear,
+                DobDay = helpRequestEntity.DobDay,
+                ContactTelephoneNumber = helpRequestEntity.ContactTelephoneNumber,
+                ContactMobileNumber = helpRequestEntity.ContactMobileNumber,
+                EmailAddress = helpRequestEntity.EmailAddress,
+                GpSurgeryDetails = helpRequestEntity.GpSurgeryDetails,
+                NumberOfChildrenUnder18 = helpRequestEntity.NumberOfChildrenUnder18,
+                ConsentToShare = helpRequestEntity.ConsentToShare,
+                DateTimeRecorded = helpRequestEntity.DateTimeRecorded,
+                RecordStatus = helpRequestEntity.RecordStatus,
+                CallbackRequired = helpRequestEntity.CallbackRequired,
+                InitialCallbackCompleted = helpRequestEntity.InitialCallbackCompleted,
+                CaseNotes = helpRequestEntity.CaseNotes,
+                AdviceNotes = helpRequestEntity.AdviceNotes,
+                HelpNeeded = helpRequestEntity.HelpNeeded
+            };
+        }
+
          public static HelpRequestCallEntity ToEntity(this HelpRequestCall helpRequestCall)
         {
             return new HelpRequestCallEntity()

--- a/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
@@ -207,7 +207,7 @@ namespace cv19ResSupportV3.V3.Factories
             };
         }
 
-         public static HelpRequest ToDomain(this HelpRequestUpdateRequest helpRequestEntity)
+        public static HelpRequest ToDomain(this HelpRequestUpdateRequest helpRequestEntity)
         {
             return new HelpRequest()
             {
@@ -273,7 +273,7 @@ namespace cv19ResSupportV3.V3.Factories
             };
         }
 
-          public static HelpRequest ToDomain(this HelpRequestPatchRequest helpRequestEntity)
+        public static HelpRequest ToDomain(this HelpRequestPatchRequest helpRequestEntity)
         {
             return new HelpRequest()
             {
@@ -318,7 +318,7 @@ namespace cv19ResSupportV3.V3.Factories
             };
         }
 
-         public static HelpRequestCallEntity ToEntity(this HelpRequestCall helpRequestCall)
+        public static HelpRequestCallEntity ToEntity(this HelpRequestCall helpRequestCall)
         {
             return new HelpRequestCallEntity()
             {

--- a/cv19ResSupportV3/V3/Factories/ResponseFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/ResponseFactory.cs
@@ -79,6 +79,72 @@ namespace cv19ResSupportV3.V3.Factories
             };
         }
 
+          public static HelpRequestUpdateResponse ToResponse(this HelpRequest helpRequest)
+        {
+            return new HelpRequestUpdateResponse()
+            {
+                Id = helpRequest.Id,
+                IsOnBehalf = helpRequest.IsOnBehalf,
+                ConsentToCompleteOnBehalf = helpRequest.ConsentToCompleteOnBehalf,
+                OnBehalfFirstName = helpRequest.OnBehalfFirstName,
+                OnBehalfLastName = helpRequest.OnBehalfLastName,
+                OnBehalfEmailAddress = helpRequest.OnBehalfEmailAddress,
+                OnBehalfContactNumber = helpRequest.OnBehalfContactNumber,
+                RelationshipWithResident = helpRequest.RelationshipWithResident,
+                PostCode = helpRequest.PostCode,
+                Uprn = helpRequest.Uprn,
+                Ward = helpRequest.Ward,
+                AddressFirstLine = helpRequest.AddressFirstLine,
+                AddressSecondLine = helpRequest.AddressSecondLine,
+                AddressThirdLine = helpRequest.AddressThirdLine,
+                GettingInTouchReason = helpRequest.GettingInTouchReason,
+                HelpWithAccessingFood = helpRequest.HelpWithAccessingFood,
+                HelpWithAccessingSupermarketFood = helpRequest.HelpWithAccessingSupermarketFood,
+                HelpWithCompletingNssForm = helpRequest.HelpWithCompletingNssForm,
+                HelpWithShieldingGuidance = helpRequest.HelpWithShieldingGuidance,
+                HelpWithNoNeedsIdentified = helpRequest.HelpWithNoNeedsIdentified,
+                HelpWithAccessingMedicine = helpRequest.HelpWithAccessingMedicine,
+                HelpWithAccessingOtherEssentials = helpRequest.HelpWithAccessingOtherEssentials,
+                HelpWithDebtAndMoney = helpRequest.HelpWithDebtAndMoney,
+                HelpWithHealth = helpRequest.HelpWithHealth,
+                HelpWithMentalHealth = helpRequest.HelpWithMentalHealth,
+                HelpWithAccessingInternet = helpRequest.HelpWithAccessingInternet,
+                HelpWithHousing = helpRequest.HelpWithHousing,
+                HelpWithJobsOrTraining = helpRequest.HelpWithJobsOrTraining,
+                HelpWithChildrenAndSchools = helpRequest.HelpWithChildrenAndSchools,
+                HelpWithDisabilities = helpRequest.HelpWithDisabilities,
+                HelpWithSomethingElse = helpRequest.HelpWithSomethingElse,
+                MedicineDeliveryHelpNeeded = helpRequest.MedicineDeliveryHelpNeeded,
+                IsPharmacistAbleToDeliver = helpRequest.IsPharmacistAbleToDeliver,
+                WhenIsMedicinesDelivered = helpRequest.WhenIsMedicinesDelivered,
+                NameAddressPharmacist = helpRequest.NameAddressPharmacist,
+                UrgentEssentials = helpRequest.UrgentEssentials,
+                UrgentEssentialsAnythingElse = helpRequest.UrgentEssentialsAnythingElse,
+                CurrentSupport = helpRequest.CurrentSupport,
+                CurrentSupportFeedback = helpRequest.CurrentSupportFeedback,
+                FirstName = helpRequest.FirstName,
+                LastName = helpRequest.LastName,
+                DobMonth = helpRequest.DobMonth,
+                DobYear = helpRequest.DobYear,
+                DobDay = helpRequest.DobDay,
+                ContactTelephoneNumber = helpRequest.ContactTelephoneNumber,
+                ContactMobileNumber = helpRequest.ContactMobileNumber,
+                EmailAddress = helpRequest.EmailAddress,
+                GpSurgeryDetails = helpRequest.GpSurgeryDetails,
+                NumberOfChildrenUnder18 = helpRequest.NumberOfChildrenUnder18,
+                ConsentToShare = helpRequest.ConsentToShare,
+                DateTimeRecorded = helpRequest.DateTimeRecorded,
+                RecordStatus = helpRequest.RecordStatus,
+                CallbackRequired = helpRequest.CallbackRequired,
+                InitialCallbackCompleted = helpRequest.InitialCallbackCompleted,
+                CaseNotes = helpRequest.CaseNotes,
+                AdviceNotes = helpRequest.AdviceNotes,
+                HelpNeeded = helpRequest.HelpNeeded,
+                NhsNumber = helpRequest.NhsNumber,
+                NhsCtasId = helpRequest.NhsCtasId
+            };
+        }
+
         public static List<HelpRequestGetResponse> ToResponse(this IEnumerable<HelpRequestEntity> responseList)
         {
             return responseList.Select(responseItem => responseItem.ToResponse()).ToList();

--- a/cv19ResSupportV3/V3/Factories/ResponseFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/ResponseFactory.cs
@@ -79,7 +79,7 @@ namespace cv19ResSupportV3.V3.Factories
             };
         }
 
-          public static HelpRequestUpdateResponse ToResponse(this HelpRequest helpRequest)
+        public static HelpRequestUpdateResponse ToResponse(this HelpRequest helpRequest)
         {
             return new HelpRequestUpdateResponse()
             {


### PR DESCRIPTION
# What
- Add missing Request and Response boundaries for `UpdateHelpRequest`
- Add missing Request boundary for `PatchHelpRequest`
- Add factory methods for mapping
- Return `HelpRequestGetResponse` boundary object from `get help request` path

# Why
To decouple boundaries from domain objects and enable further data structure changes

# Link to ticket
https://trello.com/c/eJV8rGEU/104-as-data-and-insight-officer-i-need-to-be-able-to-upload-a-prepared-list-of-tracing-cases-into-the-here-to-help-tool-so-that-they

# Notes
Not sure about `HelpRequestUpdateResponse` could possibly reuse `HelpRequestGetResponse` or `HelpRequestCreateResponse` instead

This only adds the missing boundaries, this doesn't fix all the mappings (there is still mapping from entities to boundaries and skipping domain which needs to be fixed)

This also doesn't change any logic