### PR TITLE
Resident feature

### DIFF
--- a/cv19ResSupportV3.Tests/V4/Boundary/Requests/ResidentRequestBoundaryTests.cs
+++ b/cv19ResSupportV3.Tests/V4/Boundary/Requests/ResidentRequestBoundaryTests.cs
@@ -1,0 +1,40 @@
+using AutoFixture;
+using cv19ResSupportV3.V4;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.Boundary.Requests
+{
+    [TestFixture]
+    public class ResidentRequestBoundaryTests
+    {
+        [Test]
+        public void ResidentRequestBoundaryShouldHaveTheCorrectProperties()
+        {
+            var entityType = typeof(ResidentRequestBoundary);
+            entityType.GetProperties().Length.Should().Be(21);
+            var entity = new Fixture().Create<ResidentRequestBoundary>();
+            Assert.That(entity, Has.Property("FirstName").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("LastName").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("DobDay").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("DobMonth").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("DobYear").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("ContactTelephoneNumber").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("ContactMobileNumber").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("EmailAddress").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("AddressFirstLine").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("AddressSecondLine").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("AddressThirdLine").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("Postcode").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("Uprn").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("Ward").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("IsPharmacistAbleToDeliver").InstanceOf(typeof(bool?)));
+            Assert.That(entity, Has.Property("NameAddressPharmacist").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("GpSurgeryDetails").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("NumberOfChildrenUnder18").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("ConsentToShare").InstanceOf(typeof(bool?)));
+            Assert.That(entity, Has.Property("RecordStatus").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("NhsNumber").InstanceOf(typeof(string)));
+        }
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/Boundary/Responses/ResidentResponseBoundaryTests.cs
+++ b/cv19ResSupportV3.Tests/V4/Boundary/Responses/ResidentResponseBoundaryTests.cs
@@ -1,0 +1,41 @@
+using AutoFixture;
+using cv19ResSupportV3.V4;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.Boundary.Requests
+{
+    [TestFixture]
+    public class ResidentResponseBoundaryTests
+    {
+        [Test]
+        public void ResidentRequestBoundaryShouldHaveTheCorrectProperties()
+        {
+            var entityType = typeof(ResidentResponseBoundary);
+            entityType.GetProperties().Length.Should().Be(22);
+            var entity = new Fixture().Create<ResidentResponseBoundary>();
+            Assert.That(entity, Has.Property("Id").InstanceOf(typeof(int)));
+            Assert.That(entity, Has.Property("FirstName").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("LastName").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("DobDay").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("DobMonth").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("DobYear").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("ContactTelephoneNumber").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("ContactMobileNumber").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("EmailAddress").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("AddressFirstLine").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("AddressSecondLine").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("AddressThirdLine").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("Postcode").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("Uprn").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("Ward").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("IsPharmacistAbleToDeliver").InstanceOf(typeof(bool?)));
+            Assert.That(entity, Has.Property("NameAddressPharmacist").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("GpSurgeryDetails").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("NumberOfChildrenUnder18").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("ConsentToShare").InstanceOf(typeof(bool?)));
+            Assert.That(entity, Has.Property("RecordStatus").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("NhsNumber").InstanceOf(typeof(string)));
+        }
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/Controllers/ResidentsControllerTests.cs
+++ b/cv19ResSupportV3.Tests/V4/Controllers/ResidentsControllerTests.cs
@@ -1,0 +1,68 @@
+using AutoFixture;
+using cv19ResSupportV3.V3.Boundary.Requests;
+using cv19ResSupportV3.V3.Domain.Commands;
+using cv19ResSupportV3.V4;
+using cv19ResSupportV3.V4.Controllers;
+using cv19ResSupportV3.V4.Factories;
+using cv19ResSupportV3.V4.UseCase.Interface;
+using cv19ResSupportV3.V4.UseCase.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.Controllers
+{
+    [TestFixture]
+    public class ResidentsControllerTests
+    {
+        private ResidentsController _classUnderTest;
+        private Mock<IGetResidentsUseCase> _getResidentsUseCase;
+        private Mock<ICreateResidentsUseCase> _createResidentsUseCase;
+        private Mock<IPatchResidentUseCase> _patchResidentUseCase;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _getResidentsUseCase = new Mock<IGetResidentsUseCase>();
+            _createResidentsUseCase = new Mock<ICreateResidentsUseCase>();
+            _patchResidentUseCase = new Mock<IPatchResidentUseCase>();
+            _classUnderTest = new ResidentsController(
+                _createResidentsUseCase.Object,
+                _getResidentsUseCase.Object,
+                _patchResidentUseCase.Object);
+        }
+
+        [Test]
+        public void CreateReturnsResponseWithStatus()
+        {
+            var request = new Fixture().Build<ResidentRequestBoundary>().Create();
+            _createResidentsUseCase.Setup(uc => uc.Execute(It.IsAny<ResidentRequestBoundary>()))
+                .Returns(request.ToResident().ToResponse);
+            var response = _classUnderTest.CreateResident(request) as CreatedResult;
+            response.StatusCode.Should().Be(201);
+        }
+
+        [Test]
+        public void CreateResidentCallsCreateResidentUseCaseExecuteMethod()
+        {
+            var request = new Fixture().Build<ResidentRequestBoundary>().Create();
+            _createResidentsUseCase.Setup(uc => uc.Execute(It.IsAny<ResidentRequestBoundary>()))
+                .Returns(request.ToResident().ToResponse);
+            _classUnderTest.CreateResident(request);
+            _createResidentsUseCase.Verify(uc => uc.Execute(It.IsAny<ResidentRequestBoundary>()), Times.Once);
+        }
+
+        [Test]
+        public void GetReturnsResponseWithStatus()
+        {
+            var response = new Fixture().Build<ResidentResponseBoundary>().Create();
+            _getResidentsUseCase.Setup(uc => uc.Execute(It.IsAny<int>()))
+                .Returns(response);
+            var result = _classUnderTest.GetResident(response.Id) as OkObjectResult;
+            result.StatusCode.Should().Be(200);
+        }
+
+
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/E2ETests/CreateResident.cs
+++ b/cv19ResSupportV3.Tests/V4/E2ETests/CreateResident.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using AutoFixture;
+using cv19ResSupportV3.Tests.V3.E2ETests;
+using cv19ResSupportV3.Tests.V3.Helpers;
+using cv19ResSupportV3.V3.Boundary.Response;
+using cv19ResSupportV3.V3.Boundary.Requests;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Infrastructure;
+using cv19ResSupportV3.V4;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.E2ETests
+{
+    [TestFixture]
+    public class CreateResident : IntegrationTests<Startup>
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            DatabaseContext.Database.RollbackTransaction();
+            E2ETestHelpers.ClearTable(DatabaseContext);
+        }
+
+        [Test]
+        public async Task CreateResidentRequestCreatesRecord()
+        {
+            var requestObject = new Fixture().Create<ResidentRequestBoundary>();
+            var data = JsonConvert.SerializeObject(requestObject);
+            HttpContent postContent = new StringContent(data, Encoding.UTF8, "application/json");
+            var uri = new Uri($"api/v4/residents", UriKind.Relative);
+            var response = Client.PostAsync(uri, postContent);
+            postContent.Dispose();
+            var statusCode = response.Result.StatusCode;
+            statusCode.Should().Be(201);
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<ResidentResponseBoundary>(stringContent);
+            var residentEntity = DatabaseContext.ResidentEntities.FirstOrDefault();
+            //replace with a full object comparison once we have a resident toresponse factory method
+            convertedResponse.FirstName.Should().Be(residentEntity.FirstName);
+            convertedResponse.LastName.Should().Be(residentEntity.LastName);
+        }
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/E2ETests/GetResident.cs
+++ b/cv19ResSupportV3.Tests/V4/E2ETests/GetResident.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using AutoFixture;
+using cv19ResSupportV3.Tests.V3.E2ETests;
+using cv19ResSupportV3.Tests.V3.Helpers;
+using cv19ResSupportV3.V3.Boundary.Response;
+using cv19ResSupportV3.V3.Boundary.Requests;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Infrastructure;
+using cv19ResSupportV3.V4;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.E2ETests
+{
+    [TestFixture]
+    public class GetResident : IntegrationTests<Startup>
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            DatabaseContext.Database.RollbackTransaction();
+            E2ETestHelpers.ClearTable(DatabaseContext);
+        }
+
+        [Test]
+        public async Task CreateResidentRequestCreatesRecord()
+        {
+            var resident = new Fixture().Build<ResidentEntity>()
+                .Without(re => re.HelpRequests)
+                .Without(re => re.CaseNotes)
+                .Create();
+            DatabaseContext.ResidentEntities.Add(resident);
+            DatabaseContext.SaveChanges();
+            var uri = new Uri($"api/v4/residents/{resident.Id}", UriKind.Relative);
+            var response = Client.GetAsync(uri);
+            var statusCode = response.Result.StatusCode;
+            statusCode.Should().Be(200);
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<ResidentResponseBoundary>(stringContent);
+            var residentEntity = DatabaseContext.ResidentEntities.FirstOrDefault();
+            //replace with a full object comparison once we have a resident toresponse factory method
+            convertedResponse.FirstName.Should().Be(residentEntity.FirstName);
+            convertedResponse.LastName.Should().Be(residentEntity.LastName);
+        }
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/UseCases/CreateResidentUseCaseTests.cs
+++ b/cv19ResSupportV3.Tests/V4/UseCases/CreateResidentUseCaseTests.cs
@@ -1,0 +1,38 @@
+using AutoFixture;
+using cv19ResSupportV3.V3.Domain.Commands;
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V4;
+using cv19ResSupportV3.V4.Factories;
+using cv19ResSupportV3.V4.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.UseCases
+{
+    [TestFixture]
+    public class CreateResidentUseCaseTests
+    {
+        private Mock<IResidentGateway> _mockGateway;
+        private CreateResidentsUseCase _classUnderTest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockGateway = new Mock<IResidentGateway>();
+            _classUnderTest = new CreateResidentsUseCase(_mockGateway.Object);
+        }
+
+        [Test]
+        public void ExecuteMethodCallsResidentGateway()
+        {
+            var request = new Fixture().Build<ResidentRequestBoundary>().Create();
+            _mockGateway.Setup(gw => gw.CreateResident(It.IsAny<CreateResident>())).Returns(request.ToResident());
+            var response = _classUnderTest.Execute(request);
+            _mockGateway.Verify(uc => uc.CreateResident(It.IsAny<CreateResident>()), Times.Once);
+            var expectedResponse = request.ToResident().ToResponse();
+            response.Should().BeEquivalentTo(expectedResponse);
+        }
+
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/UseCases/GetResidentUseCaseTests.cs
+++ b/cv19ResSupportV3.Tests/V4/UseCases/GetResidentUseCaseTests.cs
@@ -1,0 +1,38 @@
+using AutoFixture;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Domain.Commands;
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V4;
+using cv19ResSupportV3.V4.Factories;
+using cv19ResSupportV3.V4.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.UseCases
+{
+    [TestFixture]
+    public class GetResidentUseCaseTests
+    {
+        private Mock<IResidentGateway> _mockGateway;
+        private GetResidentsUseCase _classUnderTest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockGateway = new Mock<IResidentGateway>();
+            _classUnderTest = new GetResidentsUseCase(_mockGateway.Object);
+        }
+
+        [Test]
+        public void ExecuteMethodCallsResidentGateway()
+        {
+            var gatewayResponse = new Fixture().Build<Resident>().Create();
+            _mockGateway.Setup(gw => gw.GetResident(It.IsAny<int>())).Returns(gatewayResponse);
+            var response = _classUnderTest.Execute(gatewayResponse.Id);
+            _mockGateway.Verify(uc => uc.GetResident(It.IsAny<int>()), Times.Once);
+            response.Should().BeEquivalentTo(gatewayResponse.ToResponse());
+        }
+
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/UseCases/PatchResidentUseCaseTest.cs
+++ b/cv19ResSupportV3.Tests/V4/UseCases/PatchResidentUseCaseTest.cs
@@ -1,0 +1,38 @@
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Domain.Commands;
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V4;
+using cv19ResSupportV3.V4.Factories;
+using cv19ResSupportV3.V4.UseCase;
+using cv19ResSupportV3.V4.UseCase.Interfaces;
+using FluentAssertions;
+using LBHFSSPublicAPI.Tests.TestHelpers;
+using Moq;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.UseCase
+{
+    public class PatchResidentUseCaseTest
+    {
+        private Mock<IResidentGateway> _mockResidentGateway;
+        private PatchResidentUseCase _classUnderTest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockResidentGateway = new Mock<IResidentGateway>();
+            _classUnderTest = new PatchResidentUseCase(_mockResidentGateway.Object);
+        }
+
+        [Test]
+        public void PatchesResident()
+        {
+            var patchResident = new ResidentRequestBoundary { FirstName = "Jay", LastName = "something"};
+            _mockResidentGateway.Setup(gw => gw.PatchResident(It.IsAny<int>(), It.IsAny<PatchResident>()))
+                .Returns(patchResident.ToResident());
+            var id = Randomm.Id();
+            _classUnderTest.Execute(id, patchResident);
+            _mockResidentGateway.Verify(gw => gw.PatchResident(It.IsAny<int>(), It.IsAny<PatchResident>()), Times.Once);
+        }
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/UseCases/PatchResidentUseCaseTest.cs
+++ b/cv19ResSupportV3.Tests/V4/UseCases/PatchResidentUseCaseTest.cs
@@ -27,7 +27,7 @@ namespace cv19ResSupportV3.Tests.V4.UseCase
         [Test]
         public void PatchesResident()
         {
-            var patchResident = new ResidentRequestBoundary { FirstName = "Jay", LastName = "something"};
+            var patchResident = new ResidentRequestBoundary { FirstName = "Jay", LastName = "something" };
             _mockResidentGateway.Setup(gw => gw.PatchResident(It.IsAny<int>(), It.IsAny<PatchResident>()))
                 .Returns(patchResident.ToResident());
             var id = Randomm.Id();

--- a/cv19ResSupportV3/Startup.cs
+++ b/cv19ResSupportV3/Startup.cs
@@ -7,6 +7,8 @@ using cv19ResSupportV3.V3.Gateways;
 using cv19ResSupportV3.V3.Infrastructure;
 using cv19ResSupportV3.V3.UseCase;
 using cv19ResSupportV3.V3.UseCase.Interfaces;
+using cv19ResSupportV3.V4.UseCase;
+using cv19ResSupportV3.V4.UseCase.Interface;
 using cv19ResSupportV3.Versioning;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -47,6 +49,7 @@ namespace cv19ResSupportV3
 
             var versions = new List<ApiVersion>();
             versions.Add(new ApiVersion(3, 0));
+            // versions.Add(new ApiVersion(4, 0));
 
             foreach (var apiVersion in versions)
             {
@@ -149,7 +152,7 @@ namespace cv19ResSupportV3
             services.AddScoped<ICreateHelpRequestUseCase, CreateHelpRequestUseCase>();
             services.AddScoped<IUpdateResidentAndHelpRequestUseCase, UpdateResidentAndHelpRequestUseCase>();
             services.AddScoped<IPatchResidentAndHelpRequestUseCase, PatchResidentAndHelpRequestUseCase>();
-            services.AddScoped<IPatchResidentUseCase, PatchResidentUseCase>();
+            services.AddScoped<IPatchResidentUseCase, V3.UseCase.PatchResidentUseCase>();
             services.AddScoped<IPatchHelpRequestUseCase, PatchHelpRequestUseCase>();
             services.AddScoped<IGetResidentsAndHelpRequestsUseCase, GetResidentsAndHelpRequestsUseCase>();
             services.AddScoped<IGetResidentAndHelpRequestUseCase, GetResidentAndHelpRequestUseCase>();
@@ -164,6 +167,9 @@ namespace cv19ResSupportV3
             services.AddScoped<ICreateCaseNoteUseCase, CreateCaseNoteUseCase>();
             services.AddScoped<IUpdateCaseNoteUseCase, UpdateCaseNoteUseCase>();
             services.AddScoped<IUpdateStaffAssignmentsUseCase, UpdateStaffAssignmentsUseCase>();
+            services.AddScoped<ICreateResidentsUseCase, CreateResidentsUseCase>();
+            services.AddScoped<IGetResidentsUseCase, GetResidentsUseCase>();
+            services.AddScoped<V4.UseCase.Interfaces.IPatchResidentUseCase, V4.UseCase.PatchResidentUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/cv19ResSupportV3/V3/Boundary/Requests/HelpRequestPatchRequest.cs
+++ b/cv19ResSupportV3/V3/Boundary/Requests/HelpRequestPatchRequest.cs
@@ -43,6 +43,8 @@ namespace cv19ResSupportV3.V3.Boundary.Requests
         public string AdviceNotes { get; set; }
         public string NhsNumber { get; set; }
         public string NhsCtasId { get; set; }
+
+        public string AssignedTo { get; set; }
         public string HelpNeeded { get; set; }
     }
 }

--- a/cv19ResSupportV3/V3/Domain/Commands/PatchResidentAndHelpRequest.cs
+++ b/cv19ResSupportV3/V3/Domain/Commands/PatchResidentAndHelpRequest.cs
@@ -41,6 +41,7 @@ namespace cv19ResSupportV3.V3.Domain.Commands
         public string AdviceNotes { get; set; }
         public string NhsNumber { get; set; }
         public string NhsCtasId { get; set; }
+        public string AssignedTo { get; set; }
         public string HelpNeeded { get; set; }
     }
 }

--- a/cv19ResSupportV3/V3/Factories/Commands/PatchHelpRequestFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/Commands/PatchHelpRequestFactory.cs
@@ -48,6 +48,7 @@ namespace cv19ResSupportV3.V3.Factories.Commands
                 AdviceNotes = helpRequest.AdviceNotes,
                 NhsNumber = helpRequest.NhsNumber,
                 NhsCtasId = helpRequest.NhsCtasId,
+                AssignedTo = helpRequest.AssignedTo,
                 HelpNeeded = helpRequest.HelpNeeded,
             };
         }
@@ -78,6 +79,7 @@ namespace cv19ResSupportV3.V3.Factories.Commands
                 InitialCallbackCompleted = command.InitialCallbackCompleted,
                 AdviceNotes = command.AdviceNotes,
                 NhsCtasId = command.NhsCtasId,
+                AssignedTo = command.AssignedTo,
                 HelpNeeded = command.HelpNeeded,
             };
         }

--- a/cv19ResSupportV3/V4/Boundary/Requests/ResidentRequestBoundary.cs
+++ b/cv19ResSupportV3/V4/Boundary/Requests/ResidentRequestBoundary.cs
@@ -1,0 +1,27 @@
+namespace cv19ResSupportV3.V4
+{
+    public class ResidentRequestBoundary
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string DobDay { get; set; }
+        public string DobMonth { get; set; }
+        public string DobYear { get; set; }
+        public string ContactTelephoneNumber { get; set; }
+        public string ContactMobileNumber { get; set; }
+        public string EmailAddress { get; set; }
+        public string AddressFirstLine { get; set; }
+        public string AddressSecondLine { get; set; }
+        public string AddressThirdLine { get; set; }
+        public string Postcode { get; set; }
+        public string Uprn { get; set; }
+        public string Ward { get; set; }
+        public bool? IsPharmacistAbleToDeliver { get; set; }
+        public string NameAddressPharmacist { get; set; }
+        public string GpSurgeryDetails { get; set; }
+        public string NumberOfChildrenUnder18 { get; set; }
+        public bool? ConsentToShare { get; set; }
+        public string RecordStatus { get; set; }
+        public string NhsNumber { get; set; }
+    }
+}

--- a/cv19ResSupportV3/V4/Boundary/Responses/ResidentResponseBoundary.cs
+++ b/cv19ResSupportV3/V4/Boundary/Responses/ResidentResponseBoundary.cs
@@ -1,0 +1,28 @@
+namespace cv19ResSupportV3.V4
+{
+    public class ResidentResponseBoundary
+    {
+        public int Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string DobDay { get; set; }
+        public string DobMonth { get; set; }
+        public string DobYear { get; set; }
+        public string ContactTelephoneNumber { get; set; }
+        public string ContactMobileNumber { get; set; }
+        public string EmailAddress { get; set; }
+        public string AddressFirstLine { get; set; }
+        public string AddressSecondLine { get; set; }
+        public string AddressThirdLine { get; set; }
+        public string Postcode { get; set; }
+        public string Uprn { get; set; }
+        public string Ward { get; set; }
+        public bool? IsPharmacistAbleToDeliver { get; set; }
+        public string NameAddressPharmacist { get; set; }
+        public string GpSurgeryDetails { get; set; }
+        public string NumberOfChildrenUnder18 { get; set; }
+        public bool? ConsentToShare { get; set; }
+        public string RecordStatus { get; set; }
+        public string NhsNumber { get; set; }
+    }
+}

--- a/cv19ResSupportV3/V4/Controllers/ResidentsController.cs
+++ b/cv19ResSupportV3/V4/Controllers/ResidentsController.cs
@@ -1,0 +1,79 @@
+using System;
+using cv19ResSupportV3.V3.Controllers;
+using cv19ResSupportV3.V4.UseCase.Interface;
+using cv19ResSupportV3.V4.UseCase.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace cv19ResSupportV3.V4.Controllers
+{
+    [ApiController]
+    [Route("api/v4/residents")]
+    [Produces("application/json")]
+    // Check service api version information
+    [ApiVersion("3.0")]
+
+    public class ResidentsController: BaseController
+    {
+        private readonly ICreateResidentsUseCase _createResidentsUseCase;
+        private readonly IGetResidentsUseCase _getResidentsUseCase;
+        private readonly IPatchResidentUseCase _patchResidentsUseCase;
+
+        public ResidentsController(
+            ICreateResidentsUseCase createResidentsUseCase,
+            IGetResidentsUseCase getResidentsUseCase,
+            IPatchResidentUseCase patchResidentsUseCase)
+        {
+            _createResidentsUseCase = createResidentsUseCase;
+            _getResidentsUseCase = getResidentsUseCase;
+            _patchResidentsUseCase = patchResidentsUseCase;
+        }
+
+
+        /// <summary>
+        /// Creates a resident with the values provided.
+        /// </summary>
+        /// <response code="201">...</response>
+        [ProducesResponseType(typeof(ResidentResponseBoundary), StatusCodes.Status201Created)]
+        [HttpPost]
+        public IActionResult CreateResident(ResidentRequestBoundary request)
+        {
+            var response = _createResidentsUseCase.Execute(request);
+            if(response != null)
+                return Created(new Uri($"api/v4/residents/{response.Id}", UriKind.Relative), response);
+            return (BadRequest("Resident not created"));
+        }
+
+        /// <summary>
+        /// Gets a resident with the id specified.
+        /// </summary>
+        /// <response code="200">...</response>
+        /// <response code="404">...</response>
+        [ProducesResponseType(typeof(ResidentResponseBoundary), StatusCodes.Status200OK)]
+        [HttpGet]
+        [Route("{id}")]
+        public IActionResult GetResident(int id)
+        {
+            var response = _getResidentsUseCase.Execute(id);
+            if(response != null)
+                return Ok(response);
+            return (NotFound("Resident not found"));
+        }
+
+        /// <summary>
+        /// Updates a resident with the id specified.
+        /// </summary>
+        /// <response code="200">...</response>
+        /// <response code="404">...</response>
+        [ProducesResponseType(typeof(ResidentResponseBoundary), StatusCodes.Status200OK)]
+        [HttpPatch]
+        [Route("{id}")]
+        public IActionResult PatchResident([FromRoute] int id, [FromBody] ResidentRequestBoundary request )
+        {
+            var response = _patchResidentsUseCase.Execute(id, request);
+            if(response != null)
+                return Ok(response);
+            return (NotFound("Resident not found"));
+        }
+    }
+}

--- a/cv19ResSupportV3/V4/Controllers/ResidentsController.cs
+++ b/cv19ResSupportV3/V4/Controllers/ResidentsController.cs
@@ -13,7 +13,7 @@ namespace cv19ResSupportV3.V4.Controllers
     // Check service api version information
     [ApiVersion("3.0")]
 
-    public class ResidentsController: BaseController
+    public class ResidentsController : BaseController
     {
         private readonly ICreateResidentsUseCase _createResidentsUseCase;
         private readonly IGetResidentsUseCase _getResidentsUseCase;
@@ -39,7 +39,7 @@ namespace cv19ResSupportV3.V4.Controllers
         public IActionResult CreateResident(ResidentRequestBoundary request)
         {
             var response = _createResidentsUseCase.Execute(request);
-            if(response != null)
+            if (response != null)
                 return Created(new Uri($"api/v4/residents/{response.Id}", UriKind.Relative), response);
             return (BadRequest("Resident not created"));
         }
@@ -55,7 +55,7 @@ namespace cv19ResSupportV3.V4.Controllers
         public IActionResult GetResident(int id)
         {
             var response = _getResidentsUseCase.Execute(id);
-            if(response != null)
+            if (response != null)
                 return Ok(response);
             return (NotFound("Resident not found"));
         }
@@ -68,10 +68,10 @@ namespace cv19ResSupportV3.V4.Controllers
         [ProducesResponseType(typeof(ResidentResponseBoundary), StatusCodes.Status200OK)]
         [HttpPatch]
         [Route("{id}")]
-        public IActionResult PatchResident([FromRoute] int id, [FromBody] ResidentRequestBoundary request )
+        public IActionResult PatchResident([FromRoute] int id, [FromBody] ResidentRequestBoundary request)
         {
             var response = _patchResidentsUseCase.Execute(id, request);
-            if(response != null)
+            if (response != null)
                 return Ok(response);
             return (NotFound("Resident not found"));
         }

--- a/cv19ResSupportV3/V4/Factories/ResidentFactory.cs
+++ b/cv19ResSupportV3/V4/Factories/ResidentFactory.cs
@@ -1,0 +1,120 @@
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Domain.Commands;
+
+namespace cv19ResSupportV3.V4.Factories
+{
+    public static class ResidentFactory
+    {
+        public static CreateResident ToCommand(this ResidentRequestBoundary request)
+        {
+            return request == null ? null : new CreateResident
+            {
+                FirstName = request.FirstName,
+                LastName = request.LastName,
+                DobDay = request.DobDay,
+                DobMonth = request.DobMonth,
+                DobYear = request.DobYear,
+                ContactTelephoneNumber = request.ContactTelephoneNumber,
+                ContactMobileNumber = request.ContactMobileNumber,
+                EmailAddress = request.EmailAddress,
+                AddressFirstLine = request.AddressFirstLine,
+                AddressSecondLine = request.AddressSecondLine,
+                AddressThirdLine = request.AddressThirdLine,
+                PostCode = request.Postcode,
+                Uprn = request.Uprn,
+                Ward = request.Ward,
+                IsPharmacistAbleToDeliver = request.IsPharmacistAbleToDeliver,
+                NameAddressPharmacist = request.NameAddressPharmacist,
+                GpSurgeryDetails = request.GpSurgeryDetails,
+                NumberOfChildrenUnder18 = request.NumberOfChildrenUnder18,
+                ConsentToShare = request.ConsentToShare,
+                RecordStatus = request.RecordStatus,
+                NhsNumber = request.NhsNumber
+            };
+        }
+
+        public static ResidentResponseBoundary ToResponse(this Resident domain)
+        {
+            return domain == null ? null : new ResidentResponseBoundary
+            {
+                FirstName = domain.FirstName,
+                LastName = domain.LastName,
+                DobDay = domain.DobDay,
+                DobMonth = domain.DobMonth,
+                DobYear = domain.DobYear,
+                ContactTelephoneNumber = domain.ContactTelephoneNumber,
+                ContactMobileNumber = domain.ContactMobileNumber,
+                EmailAddress = domain.EmailAddress,
+                AddressFirstLine = domain.AddressFirstLine,
+                AddressSecondLine = domain.AddressSecondLine,
+                AddressThirdLine = domain.AddressThirdLine,
+                Postcode = domain.PostCode,
+                Uprn = domain.Uprn,
+                Ward = domain.Ward,
+                IsPharmacistAbleToDeliver = domain.IsPharmacistAbleToDeliver,
+                NameAddressPharmacist = domain.NameAddressPharmacist,
+                GpSurgeryDetails = domain.GpSurgeryDetails,
+                NumberOfChildrenUnder18 = domain.NumberOfChildrenUnder18,
+                ConsentToShare = domain.ConsentToShare,
+                RecordStatus = domain.RecordStatus,
+                NhsNumber = domain.NhsNumber
+            };
+        }
+
+        public static Resident ToResident(this ResidentRequestBoundary request)
+        {
+            return request == null ? null : new Resident
+            {
+                FirstName = request.FirstName,
+                LastName = request.LastName,
+                DobDay = request.DobDay,
+                DobMonth = request.DobMonth,
+                DobYear = request.DobYear,
+                ContactTelephoneNumber = request.ContactTelephoneNumber,
+                ContactMobileNumber = request.ContactMobileNumber,
+                EmailAddress = request.EmailAddress,
+                AddressFirstLine = request.AddressFirstLine,
+                AddressSecondLine = request.AddressSecondLine,
+                AddressThirdLine = request.AddressThirdLine,
+                PostCode = request.Postcode,
+                Uprn = request.Uprn,
+                Ward = request.Ward,
+                IsPharmacistAbleToDeliver = request.IsPharmacistAbleToDeliver,
+                NameAddressPharmacist = request.NameAddressPharmacist,
+                GpSurgeryDetails = request.GpSurgeryDetails,
+                NumberOfChildrenUnder18 = request.NumberOfChildrenUnder18,
+                ConsentToShare = request.ConsentToShare,
+                RecordStatus = request.RecordStatus,
+                NhsNumber = request.NhsNumber
+            };
+        }
+
+        public static PatchResident ToPatchResident(this ResidentRequestBoundary request)
+        {
+            return request == null ? null : new PatchResident
+            {
+                FirstName = request.FirstName,
+                LastName = request.LastName,
+                DobDay = request.DobDay,
+                DobMonth = request.DobMonth,
+                DobYear = request.DobYear,
+                ContactTelephoneNumber = request.ContactTelephoneNumber,
+                ContactMobileNumber = request.ContactMobileNumber,
+                EmailAddress = request.EmailAddress,
+                AddressFirstLine = request.AddressFirstLine,
+                AddressSecondLine = request.AddressSecondLine,
+                AddressThirdLine = request.AddressThirdLine,
+                PostCode = request.Postcode,
+                Uprn = request.Uprn,
+                Ward = request.Ward,
+                IsPharmacistAbleToDeliver = request.IsPharmacistAbleToDeliver,
+                NameAddressPharmacist = request.NameAddressPharmacist,
+                GpSurgeryDetails = request.GpSurgeryDetails,
+                NumberOfChildrenUnder18 = request.NumberOfChildrenUnder18,
+                ConsentToShare = request.ConsentToShare,
+                RecordStatus = request.RecordStatus,
+                NhsNumber = request.NhsNumber
+            };
+        }
+    }
+}

--- a/cv19ResSupportV3/V4/UseCase/CreateResidentsUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/CreateResidentsUseCase.cs
@@ -1,0 +1,22 @@
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V3.UseCase;
+using cv19ResSupportV3.V4.Factories;
+using cv19ResSupportV3.V4.UseCase.Interface;
+
+namespace cv19ResSupportV3.V4.UseCase
+{
+    public class CreateResidentsUseCase : ICreateResidentsUseCase
+    {
+        private readonly IResidentGateway _gateway;
+
+        public CreateResidentsUseCase(IResidentGateway gateway)
+        {
+            _gateway = gateway;
+        }
+        public ResidentResponseBoundary Execute(ResidentRequestBoundary request)
+        {
+            var gwResponse = _gateway.CreateResident(request.ToCommand());
+            return gwResponse.ToResponse();
+        }
+    }
+}

--- a/cv19ResSupportV3/V4/UseCase/GetResidentsUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/GetResidentsUseCase.cs
@@ -1,0 +1,22 @@
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V3.UseCase;
+using cv19ResSupportV3.V4.Factories;
+using cv19ResSupportV3.V4.UseCase.Interface;
+
+namespace cv19ResSupportV3.V4.UseCase
+{
+    public class GetResidentsUseCase : IGetResidentsUseCase
+    {
+        private readonly IResidentGateway _gateway;
+
+        public GetResidentsUseCase(IResidentGateway gateway)
+        {
+            _gateway = gateway;
+        }
+        public ResidentResponseBoundary Execute(int id)
+        {
+            var gwResponse = _gateway.GetResident(id);
+            return gwResponse.ToResponse();
+        }
+    }
+}

--- a/cv19ResSupportV3/V4/UseCase/Interface/ICreateResidentsUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/Interface/ICreateResidentsUseCase.cs
@@ -1,0 +1,7 @@
+namespace cv19ResSupportV3.V4.UseCase.Interface
+{
+    public interface ICreateResidentsUseCase
+    {
+        ResidentResponseBoundary Execute(ResidentRequestBoundary request);
+    }
+}

--- a/cv19ResSupportV3/V4/UseCase/Interface/IGetResidentsUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/Interface/IGetResidentsUseCase.cs
@@ -1,0 +1,7 @@
+namespace cv19ResSupportV3.V4.UseCase.Interface
+{
+    public interface IGetResidentsUseCase
+    {
+        ResidentResponseBoundary Execute(int id);
+    }
+}

--- a/cv19ResSupportV3/V4/UseCase/Interface/IPatchResidentUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/Interface/IPatchResidentUseCase.cs
@@ -1,0 +1,9 @@
+using cv19ResSupportV3.V3.Domain.Commands;
+
+namespace cv19ResSupportV3.V4.UseCase.Interfaces
+{
+    public interface IPatchResidentUseCase
+    {
+        ResidentResponseBoundary Execute(int id, ResidentRequestBoundary command);
+    }
+}

--- a/cv19ResSupportV3/V4/UseCase/PatchResidentUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/PatchResidentUseCase.cs
@@ -1,0 +1,21 @@
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V4.Factories;
+using cv19ResSupportV3.V4.UseCase.Interfaces;
+
+namespace cv19ResSupportV3.V4.UseCase
+{
+    public class PatchResidentUseCase : IPatchResidentUseCase
+    {
+        private readonly IResidentGateway _residentGateway;
+        public PatchResidentUseCase(IResidentGateway residentGateway)
+        {
+            _residentGateway = residentGateway;
+        }
+
+        public ResidentResponseBoundary Execute(int id, ResidentRequestBoundary command)
+        {
+            var gwResponse = _residentGateway.PatchResident(id, command.ToPatchResident());
+            return gwResponse.ToResponse();
+        }
+    }
+}


### PR DESCRIPTION
# What
- Added a new resident feature providing the standard REST operations:
- GET - residents (search residents)
- GET - residents/{id} (get a single resident by id)
- POST - residents (create a new resident)
- PATCH - residents/{id} (update the resident with the specified id)

# Why
- These endpoints are required to work with resident data via the API.  It is part of the new feature set that allow the saving of residents' information separate from the requests they make.

# Screenshots


# Link to ticket
https://trello.com/c/FoIGcpjg/246-api-resident-endpoints

# Notes


