### PR TITLE
Help request default date

### DIFF
--- a/cv19ResSupportV3/V3/Factories/Commands/CreateHelpRequestFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/Commands/CreateHelpRequestFactory.cs
@@ -87,7 +87,7 @@ namespace cv19ResSupportV3.V3.Factories.Commands
                 UrgentEssentialsAnythingElse = helpRequest.UrgentEssentialsAnythingElse,
                 CurrentSupport = helpRequest.CurrentSupport,
                 CurrentSupportFeedback = helpRequest.CurrentSupportFeedback,
-                DateTimeRecorded = helpRequest.DateTimeRecorded?? DateTime.Now,
+                DateTimeRecorded = helpRequest.DateTimeRecorded ?? DateTime.Now,
                 CallbackRequired = helpRequest.CallbackRequired,
                 InitialCallbackCompleted = helpRequest.InitialCallbackCompleted,
                 AdviceNotes = helpRequest.AdviceNotes,

--- a/cv19ResSupportV3/V3/Factories/Commands/CreateHelpRequestFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/Commands/CreateHelpRequestFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using cv19ResSupportV3.V3.Domain.Commands;
 using cv19ResSupportV3.V3.Infrastructure;
 
@@ -86,7 +87,7 @@ namespace cv19ResSupportV3.V3.Factories.Commands
                 UrgentEssentialsAnythingElse = helpRequest.UrgentEssentialsAnythingElse,
                 CurrentSupport = helpRequest.CurrentSupport,
                 CurrentSupportFeedback = helpRequest.CurrentSupportFeedback,
-                DateTimeRecorded = helpRequest.DateTimeRecorded,
+                DateTimeRecorded = helpRequest.DateTimeRecorded?? DateTime.Now,
                 CallbackRequired = helpRequest.CallbackRequired,
                 InitialCallbackCompleted = helpRequest.InitialCallbackCompleted,
                 AdviceNotes = helpRequest.AdviceNotes,

--- a/cv19ResSupportV3/V4/Factories/HelpRequestFactory.cs
+++ b/cv19ResSupportV3/V4/Factories/HelpRequestFactory.cs
@@ -46,7 +46,7 @@ namespace cv19ResSupportV3.V4.Factories
                     UrgentEssentialsAnythingElse = request.UrgentEssentials,
                     CurrentSupport = request.CurrentSupport,
                     CurrentSupportFeedback = request.CurrentSupportFeedback,
-                    DateTimeRecorded = request.DateTimeRecorded?? DateTime.Now,
+                    DateTimeRecorded = request.DateTimeRecorded ?? DateTime.Now,
                     InitialCallbackCompleted = request.InitialCallbackCompleted,
                     CallbackRequired = request.CallbackRequired,
                     AdviceNotes = request.AdviceNotes,

--- a/cv19ResSupportV3/V4/Factories/HelpRequestFactory.cs
+++ b/cv19ResSupportV3/V4/Factories/HelpRequestFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using cv19ResSupportV3.V3.Domain;
@@ -45,7 +46,7 @@ namespace cv19ResSupportV3.V4.Factories
                     UrgentEssentialsAnythingElse = request.UrgentEssentials,
                     CurrentSupport = request.CurrentSupport,
                     CurrentSupportFeedback = request.CurrentSupportFeedback,
-                    DateTimeRecorded = request.DateTimeRecorded,
+                    DateTimeRecorded = request.DateTimeRecorded?? DateTime.Now,
                     InitialCallbackCompleted = request.InitialCallbackCompleted,
                     CallbackRequired = request.CallbackRequired,
                     AdviceNotes = request.AdviceNotes,


### PR DESCRIPTION
# What
- Adds a default date to help requests if none is provided.

# Why
- This is to ensure that no help request is without a creation date.

# Screenshots


# Link to ticket


# Notes


