### PR TITLE
Resident help request fixes

### DIFF
--- a/cv19ResSupportV3/V4/Controllers/ResidentHelpRequestsController.cs
+++ b/cv19ResSupportV3/V4/Controllers/ResidentHelpRequestsController.cs
@@ -55,7 +55,7 @@ namespace cv19ResSupportV3.V4.Controllers
         [ProducesResponseType(typeof(ResidentHelpRequestResponse), StatusCodes.Status200OK)]
         [HttpGet]
         [Route("{help-request-id}")]
-        public IActionResult GetResidentHelpRequest(int id, int helpRequestId)
+        public IActionResult GetResidentHelpRequest([FromRoute(Name = "id")] int id, [FromRoute(Name = "help-request-id")] int helpRequestId)
         {
             var response = _getResidentHelpRequestUseCase.Execute(id, helpRequestId);
             if (response != null)

--- a/cv19ResSupportV3/V4/Controllers/ResidentHelpRequestsController.cs
+++ b/cv19ResSupportV3/V4/Controllers/ResidentHelpRequestsController.cs
@@ -86,7 +86,7 @@ namespace cv19ResSupportV3.V4.Controllers
         [ProducesResponseType(typeof(ResidentResponseBoundary), StatusCodes.Status200OK)]
         [HttpPatch]
         [Route("{help-request-id}")]
-        public IActionResult PatchResidentHelpRequest([FromRoute] int id, [FromRoute] int helpRequestId, [FromBody] ResidentHelpRequestRequest request)
+        public IActionResult PatchResidentHelpRequest([FromRoute(Name = "id")] int id, [FromRoute(Name = "help-request-id")] int helpRequestId, [FromBody] ResidentHelpRequestRequest request)
         {
             var response = _patchResidentHelpRequestUseCase.Execute(id, helpRequestId, request);
             if (response != null)


### PR DESCRIPTION
# What
- Fixed an issue where an existing help request isn't found when getting or patching an individual help request

# Why
- Individual resident help requests should be accessible from the ids provided

# Screenshots


# Link to ticket


# Notes
- The route params could not be found to pass to the use cases.  These route params needed to be explicitly identified using 
`[FromRoute(Name = "id")] int id, [FromRoute(Name = "help-request-id")] int helpRequestId` on the controllers
