### PR TITLE
Update Swagger Script

### DIFF
--- a/cv19ResSupportV3/Startup.cs
+++ b/cv19ResSupportV3/Startup.cs
@@ -49,7 +49,7 @@ namespace cv19ResSupportV3
 
             var versions = new List<ApiVersion>();
             versions.Add(new ApiVersion(3, 0));
-            // versions.Add(new ApiVersion(4, 0));
+            versions.Add(new ApiVersion(4, 0));
 
             foreach (var apiVersion in versions)
             {

--- a/cv19ResSupportV3/V4/Controllers/ResidentHelpRequestsController.cs
+++ b/cv19ResSupportV3/V4/Controllers/ResidentHelpRequestsController.cs
@@ -14,7 +14,7 @@ namespace cv19ResSupportV3.V4.Controllers
     [Route("api/v4/residents/{id}/help-requests")]
     [Produces("application/json")]
     // Check service api version information
-    [ApiVersion("3.0")]
+    [ApiVersion("4.0")]
 
     public class ResidentHelpRequestsController : BaseController
     {

--- a/cv19ResSupportV3/V4/Controllers/ResidentsController.cs
+++ b/cv19ResSupportV3/V4/Controllers/ResidentsController.cs
@@ -14,7 +14,7 @@ namespace cv19ResSupportV3.V4.Controllers
     [Route("api/v4/residents")]
     [Produces("application/json")]
     // Check service api version information
-    [ApiVersion("3.0")]
+    [ApiVersion("4.0")]
 
     public class ResidentsController : BaseController
     {

--- a/cv19ResSupportV3/publish-to-swagger-hub
+++ b/cv19ResSupportV3/publish-to-swagger-hub
@@ -21,11 +21,20 @@ then
     npm i -g --silent swaggerhub-cli
 fi
 
+
 owner="Hackney"
 api_name="here-to-help"
-api_version="v3.0"
+api_version=$1
+stage=$2
 
-if [ "$1" = "production"  ]
+if [ -z "$api_version" ]
+then
+    echo "Usage: publish-to-swagger-hub VERSION [STAGE]"
+    echo "Example: publish-to-swagger-hub v3.0"
+    exit 1
+fi
+
+if [ "$stage" = "production"  ]
 then
     swagger_version="$api_version"
     echo "Stage is production, therefore will name this version '${swagger_version}'"
@@ -51,9 +60,9 @@ swagger_path="${owner}/${api_name}/${swagger_version}"
 
 if [ -z "$(swaggerhub api:get "${swagger_path}")" ]
 then
-    swaggerhub api:create "$swagger_path" --file "${json_file}"
+    swaggerhub api:create "$swagger_path" --visibility=public --file "${json_file}"
 else
-    swaggerhub api:update "$swagger_path" --file "${json_file}"
+    swaggerhub api:update "$swagger_path" --visibility=public --file "${json_file}"
 fi
 
 echo "Cleaning up ${tmp_dir}"


### PR DESCRIPTION

# What
In order to publish the v4.0 documentation easily, I've updated the swagger publish script, and added the correct v4.0 annotations to the controller

Usage now for production:
./cv19ResSupportV3/publish-to-swagger-hub v3.0 production
./cv19ResSupportV3/publish-to-swagger-hub v4.0 production

For development
./cv19ResSupportV3/publish-to-swagger-hub v3.0 development
./cv19ResSupportV3/publish-to-swagger-hub v4.0 development
# Why

Because we deserve up to date documentation

# Screenshots


# Link to ticket


# Notes


