### PR TITLE
Add Casenotes to help requests

### DIFF
--- a/cv19ResSupportV3.Tests/V3/E2ETests/CreateHelpRequest.cs
+++ b/cv19ResSupportV3.Tests/V3/E2ETests/CreateHelpRequest.cs
@@ -80,9 +80,9 @@ namespace cv19ResSupportV3.Tests.V3.E2ETests
             residentEntity.Uprn.Should().BeEquivalentTo(requestObject.Uprn);
             residentEntity.AddressFirstLine.Should().BeEquivalentTo(requestObject.AddressFirstLine);
             residentEntity.ContactMobileNumber.Should()
-                .BeEquivalentTo(existingResident.ContactMobileNumber + "/" + requestObject.ContactMobileNumber);
+                .BeEquivalentTo(existingResident.ContactMobileNumber + " / " + requestObject.ContactMobileNumber);
             residentEntity.ContactTelephoneNumber.Should()
-                .BeEquivalentTo(existingResident.ContactTelephoneNumber + "/" + requestObject.ContactTelephoneNumber);
+                .BeEquivalentTo(existingResident.ContactTelephoneNumber + " / " + requestObject.ContactTelephoneNumber);
             helpRequestEntity.HelpWithAccessingSupermarketFood.Should().Be(requestObject.HelpWithAccessingSupermarketFood);
             helpRequestEntity.HelpWithCompletingNssForm.Should().Be(requestObject.HelpWithCompletingNssForm);
             helpRequestEntity.HelpWithShieldingGuidance.Should().Be(requestObject.HelpWithShieldingGuidance);

--- a/cv19ResSupportV3.Tests/V3/UseCase/CreateResidentUseCaseTest.cs
+++ b/cv19ResSupportV3.Tests/V3/UseCase/CreateResidentUseCaseTest.cs
@@ -81,5 +81,109 @@ namespace cv19ResSupportV3.Tests.V3.UseCase
             _mockGateway.Verify(m => m.PatchResident(It.IsAny<int>(), It.IsAny<PatchResident>()), Times.Once());
             response.Should().Be(updatedResident);
         }
+        [Test]
+        public void DoesntConcatSameNumbers()
+        {
+            _residentDomain.ContactTelephoneNumber = "123";
+            _residentDomain.ContactMobileNumber = "456";
+            _createResidentCommand.ContactTelephoneNumber = "123";
+            _createResidentCommand.ContactMobileNumber = "456";
+
+            var updatedResident = _residentDomain;
+
+            _mockGateway.Setup(s => s.FindResident(It.IsAny<FindResident>())).Returns(1);
+            _mockGateway.Setup(s => s.GetResident(It.IsAny<int>())).Returns(_residentDomain);
+            _mockGateway.Setup(s => s.PatchResident(It.IsAny<int>(), It.IsAny<PatchResident>())).Returns(updatedResident);
+
+            var response = _classUnderTest.Execute(_createResidentCommand);
+
+            _mockGateway.Verify(m => m.FindResident(It.IsAny<FindResident>()), Times.Once());
+            _mockGateway.Verify(m => m.GetResident(It.IsAny<int>()), Times.Once());
+            _mockGateway.Verify(m => m.CreateResident(It.IsAny<CreateResident>()), Times.Never());
+            _mockGateway.Verify(m => m.PatchResident(
+                It.IsAny<int>(),
+                It.Is<PatchResident>(
+                    x => x.ContactTelephoneNumber == "123" && x.ContactMobileNumber == "456"
+                )
+            ), Times.Once());
+        }
+        [Test]
+        public void DoesntConcatNullNumbers()
+        {
+            _residentDomain.ContactTelephoneNumber = "123";
+            _residentDomain.ContactMobileNumber = "456";
+            _createResidentCommand.ContactTelephoneNumber = "";
+            _createResidentCommand.ContactMobileNumber = null;
+
+            var updatedResident = _residentDomain;
+
+            _mockGateway.Setup(s => s.FindResident(It.IsAny<FindResident>())).Returns(1);
+            _mockGateway.Setup(s => s.GetResident(It.IsAny<int>())).Returns(_residentDomain);
+            _mockGateway.Setup(s => s.PatchResident(It.IsAny<int>(), It.IsAny<PatchResident>())).Returns(updatedResident);
+
+            var response = _classUnderTest.Execute(_createResidentCommand);
+
+            _mockGateway.Verify(m => m.FindResident(It.IsAny<FindResident>()), Times.Once());
+            _mockGateway.Verify(m => m.GetResident(It.IsAny<int>()), Times.Once());
+            _mockGateway.Verify(m => m.CreateResident(It.IsAny<CreateResident>()), Times.Never());
+            _mockGateway.Verify(m => m.PatchResident(
+                It.IsAny<int>(),
+                It.Is<PatchResident>(
+                    x => x.ContactTelephoneNumber == "123" && x.ContactMobileNumber == "456"
+                )
+            ), Times.Once());
+        }
+        [Test]
+        public void SavesNewNumbers()
+        {
+            _residentDomain.ContactTelephoneNumber = null;
+            _residentDomain.ContactMobileNumber = "";
+            _createResidentCommand.ContactTelephoneNumber = "123";
+            _createResidentCommand.ContactMobileNumber = "456";
+
+            var updatedResident = _residentDomain;
+
+            _mockGateway.Setup(s => s.FindResident(It.IsAny<FindResident>())).Returns(1);
+            _mockGateway.Setup(s => s.GetResident(It.IsAny<int>())).Returns(_residentDomain);
+            _mockGateway.Setup(s => s.PatchResident(It.IsAny<int>(), It.IsAny<PatchResident>())).Returns(updatedResident);
+
+            var response = _classUnderTest.Execute(_createResidentCommand);
+
+            _mockGateway.Verify(m => m.FindResident(It.IsAny<FindResident>()), Times.Once());
+            _mockGateway.Verify(m => m.GetResident(It.IsAny<int>()), Times.Once());
+            _mockGateway.Verify(m => m.CreateResident(It.IsAny<CreateResident>()), Times.Never());
+            _mockGateway.Verify(m => m.PatchResident(
+                It.IsAny<int>(),
+                It.Is<PatchResident>(
+                    x => x.ContactTelephoneNumber == "123" && x.ContactMobileNumber == "456"
+                )
+            ), Times.Once());
+        }
+        [Test]
+        public void ConcatDifferentNumbers()
+        {
+            _residentDomain.ContactTelephoneNumber = "123";
+            _residentDomain.ContactMobileNumber = "456";
+            _createResidentCommand.ContactTelephoneNumber = "789";
+            _createResidentCommand.ContactMobileNumber = "012";
+
+            var updatedResident = _residentDomain;
+
+            _mockGateway.Setup(s => s.FindResident(It.IsAny<FindResident>())).Returns(1);
+            _mockGateway.Setup(s => s.GetResident(It.IsAny<int>())).Returns(_residentDomain);
+            _mockGateway.Setup(s => s.PatchResident(It.IsAny<int>(), It.IsAny<PatchResident>())).Returns(updatedResident);
+
+            var response = _classUnderTest.Execute(_createResidentCommand);
+
+            _mockGateway.Verify(m => m.FindResident(It.IsAny<FindResident>()), Times.Once());
+            _mockGateway.Verify(m => m.GetResident(It.IsAny<int>()), Times.Once());
+            _mockGateway.Verify(m => m.CreateResident(It.IsAny<CreateResident>()), Times.Never());
+            _mockGateway.Verify(m => m.PatchResident(
+                It.IsAny<int>(),
+                It.Is<PatchResident>(
+                    x => x.ContactTelephoneNumber == "123 / 789" && x.ContactMobileNumber == "456 / 012"
+                )
+            ), Times.Once());
+        }
     }
 }

--- a/cv19ResSupportV3.Tests/V4/E2ETests/GetResident.cs
+++ b/cv19ResSupportV3.Tests/V4/E2ETests/GetResident.cs
@@ -1,18 +1,11 @@
 using System;
 using System.Linq;
-using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using AutoFixture;
 using cv19ResSupportV3.Tests.V3.E2ETests;
-using cv19ResSupportV3.Tests.V3.Helpers;
-using cv19ResSupportV3.V3.Boundary.Response;
-using cv19ResSupportV3.V3.Boundary.Requests;
-using cv19ResSupportV3.V3.Domain;
 using cv19ResSupportV3.V3.Infrastructure;
 using cv19ResSupportV3.V4;
 using FluentAssertions;
-using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using NUnit.Framework;
 

--- a/cv19ResSupportV3.Tests/V4/E2ETests/GetResidentHelpRequests.cs
+++ b/cv19ResSupportV3.Tests/V4/E2ETests/GetResidentHelpRequests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture;
+using cv19ResSupportV3.Tests.V3.E2ETests;
+using cv19ResSupportV3.Tests.V3.Helpers;
+using cv19ResSupportV3.V3.Boundary.Response;
+using cv19ResSupportV3.V3.Infrastructure;
+using cv19ResSupportV3.V4;
+using cv19ResSupportV3.V4.Boundary.Response;
+using cv19ResSupportV3.V4.Factories;
+using FluentAssertions;
+using LBHFSSPublicAPI.Tests.TestHelpers;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.E2ETests
+{
+    [TestFixture]
+    public class GetResidentHelpRequests: IntegrationTests<Startup>
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            DatabaseContext.Database.RollbackTransaction();
+            E2ETestHelpers.ClearTable(DatabaseContext);
+        }
+        [Test]
+        public async Task GetResidentHelpRequestsRequestGetsRecordWithCaseNotes()
+        {
+            var residentEntity = EntityHelpers.createResident(114);
+            var helpRequestEntity = EntityHelpers.createHelpRequestEntity(43, residentEntity.Id);
+            var caseNoteEntity = new CaseNoteEntity { CaseNote = "before update", ResidentId = residentEntity.Id, HelpRequestId = helpRequestEntity.Id };
+
+
+            DatabaseContext.ResidentEntities.Add(residentEntity);
+            DatabaseContext.HelpRequestEntities.Add(helpRequestEntity);
+            DatabaseContext.CaseNoteEntities.Add(caseNoteEntity);
+
+            DatabaseContext.SaveChanges();
+
+            var expectedResponse = helpRequestEntity.ToRequestResponse(residentEntity);
+
+            var requestUri = new Uri($"api/v4/residents/{residentEntity.Id}/help-requests/{helpRequestEntity.Id}", UriKind.Relative);
+            var response = Client.GetAsync(requestUri);
+            var statusCode = response.Result.StatusCode;
+
+            statusCode.Should().Be(200);
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<ResidentHelpRequestResponse>(stringContent);
+
+            convertedResponse.Should().BeEquivalentTo(expectedResponse, options =>
+            {
+                options.Excluding(ex => ex.HelpRequestCalls);
+                options.Excluding(ex => ex.DateTimeRecorded);
+                return options;
+            });
+            Assert.That(convertedResponse.DateTimeRecorded, Is.EqualTo(expectedResponse.DateTimeRecorded).Within(1).Seconds);
+        }
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/E2ETests/GetResidentHelpRequests.cs
+++ b/cv19ResSupportV3.Tests/V4/E2ETests/GetResidentHelpRequests.cs
@@ -17,7 +17,7 @@ using NUnit.Framework;
 namespace cv19ResSupportV3.Tests.V4.E2ETests
 {
     [TestFixture]
-    public class GetResidentHelpRequests: IntegrationTests<Startup>
+    public class GetResidentHelpRequests : IntegrationTests<Startup>
     {
         [SetUp]
         public void SetUp()

--- a/cv19ResSupportV3/V3/UseCase/CreateResidentUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/CreateResidentUseCase.cs
@@ -27,14 +27,26 @@ namespace cv19ResSupportV3.V3.UseCase
                 string[] telephoneNumbers = { existingResident.ContactTelephoneNumber, updateResident.ContactTelephoneNumber };
                 string[] mobileNumbers = { existingResident.ContactMobileNumber, updateResident.ContactMobileNumber };
 
-                updateResident.ContactTelephoneNumber = String.Join("/", telephoneNumbers.Where(x => !string.IsNullOrEmpty(x)));
-                updateResident.ContactMobileNumber = String.Join("/", mobileNumbers.Where(x => !string.IsNullOrEmpty(x)));
+                updateResident.ContactTelephoneNumber = ConcatPhoneNumber(existingResident.ContactTelephoneNumber, updateResident.ContactTelephoneNumber);
+                updateResident.ContactMobileNumber = ConcatPhoneNumber(existingResident.ContactMobileNumber,
+                    updateResident.ContactMobileNumber);
                 return _gateway.PatchResident((int) existingResidentId, updateResident);
             }
             var resident = _gateway.CreateResident(command);
             return resident;
         }
 
-
+        private string ConcatPhoneNumber(string existingNumber, string newNumber)
+        {
+            if (string.IsNullOrEmpty(existingNumber))
+            {
+                return newNumber;
+            }
+            else if (string.IsNullOrEmpty(newNumber) || existingNumber.Contains(newNumber))
+            {
+                return existingNumber;
+            }
+            return String.Join(" / ", existingNumber, newNumber);
+        }
     }
 }

--- a/cv19ResSupportV3/V4/Factories/HelpRequestFactory.cs
+++ b/cv19ResSupportV3/V4/Factories/HelpRequestFactory.cs
@@ -120,7 +120,7 @@ namespace cv19ResSupportV3.V4.Factories
                     MedicineDeliveryHelpNeeded = domain.MedicineDeliveryHelpNeeded,
                     WhenIsMedicinesDelivered = domain.WhenIsMedicinesDelivered,
                     UrgentEssentials = domain.UrgentEssentials,
-                    UrgentEssentialsAnythingElse = domain.UrgentEssentials,
+                    UrgentEssentialsAnythingElse = domain.UrgentEssentialsAnythingElse,
                     CurrentSupport = domain.CurrentSupport,
                     CurrentSupportFeedback = domain.CurrentSupportFeedback,
                     DateTimeRecorded = domain.DateTimeRecorded,
@@ -168,7 +168,7 @@ namespace cv19ResSupportV3.V4.Factories
                     MedicineDeliveryHelpNeeded = domain.MedicineDeliveryHelpNeeded,
                     WhenIsMedicinesDelivered = domain.WhenIsMedicinesDelivered,
                     UrgentEssentials = domain.UrgentEssentials,
-                    UrgentEssentialsAnythingElse = domain.UrgentEssentials,
+                    UrgentEssentialsAnythingElse = domain.UrgentEssentialsAnythingElse,
                     CurrentSupport = domain.CurrentSupport,
                     CurrentSupportFeedback = domain.CurrentSupportFeedback,
                     DateTimeRecorded = domain.DateTimeRecorded,
@@ -178,7 +178,8 @@ namespace cv19ResSupportV3.V4.Factories
                     HelpNeeded = domain.HelpNeeded,
                     AssignedTo = domain.AssignedTo,
                     NhsCtasId = domain.NhsCtasId,
-                    HelpRequestCalls = domain.HelpRequestCalls
+                    HelpRequestCalls = domain.HelpRequestCalls,
+                    CaseNotes = domain.CaseNotes
                 };
         }
 

--- a/cv19ResSupportV3/V4/Factories/ResponseFactory.cs
+++ b/cv19ResSupportV3/V4/Factories/ResponseFactory.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using cv19ResSupportV3.V3.Boundary.Response;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Factories;
+using cv19ResSupportV3.V3.Infrastructure;
+using cv19ResSupportV3.V4.Boundary.Response;
+
+namespace cv19ResSupportV3.V4.Factories
+{
+    public static class ResponseFactory
+    {
+        public static ResidentHelpRequestResponse ToRequestResponse(this HelpRequestEntity hr,
+            ResidentEntity resident)
+        {
+            if (hr == null || resident == null)
+            {
+                return null;
+            }
+
+            return new ResidentHelpRequestResponse
+            {
+                Id = hr.Id,
+                ResidentId = hr.ResidentId,
+                IsOnBehalf = hr.IsOnBehalf,
+                ConsentToCompleteOnBehalf = hr.ConsentToCompleteOnBehalf,
+                OnBehalfFirstName = hr.OnBehalfFirstName,
+                OnBehalfLastName = hr.OnBehalfLastName,
+                OnBehalfEmailAddress = hr.OnBehalfEmailAddress,
+                OnBehalfContactNumber = hr.OnBehalfContactNumber,
+                RelationshipWithResident = hr.RelationshipWithResident,
+                GettingInTouchReason = hr.GettingInTouchReason,
+                HelpWithAccessingFood = hr.HelpWithAccessingFood,
+                HelpWithAccessingSupermarketFood = hr.HelpWithAccessingSupermarketFood,
+                HelpWithCompletingNssForm = hr.HelpWithCompletingNssForm,
+                HelpWithShieldingGuidance = hr.HelpWithShieldingGuidance,
+                HelpWithNoNeedsIdentified = hr.HelpWithNoNeedsIdentified,
+                HelpWithAccessingMedicine = hr.HelpWithAccessingMedicine,
+                HelpWithAccessingOtherEssentials = hr.HelpWithAccessingOtherEssentials,
+                HelpWithDebtAndMoney = hr.HelpWithDebtAndMoney,
+                HelpWithHealth = hr.HelpWithHealth,
+                HelpWithMentalHealth = hr.HelpWithMentalHealth,
+                HelpWithAccessingInternet = hr.HelpWithAccessingInternet,
+                HelpWithHousing = hr.HelpWithHousing,
+                HelpWithJobsOrTraining = hr.HelpWithJobsOrTraining,
+                HelpWithChildrenAndSchools = hr.HelpWithChildrenAndSchools,
+                HelpWithDisabilities = hr.HelpWithDisabilities,
+                HelpWithSomethingElse = hr.HelpWithSomethingElse,
+                MedicineDeliveryHelpNeeded = hr.MedicineDeliveryHelpNeeded,
+                WhenIsMedicinesDelivered = hr.WhenIsMedicinesDelivered,
+                UrgentEssentials = hr.UrgentEssentials,
+                UrgentEssentialsAnythingElse = hr.UrgentEssentialsAnythingElse,
+                CurrentSupport = hr.CurrentSupport,
+                CurrentSupportFeedback = hr.CurrentSupportFeedback,
+                DateTimeRecorded = hr.DateTimeRecorded,
+                InitialCallbackCompleted = hr.InitialCallbackCompleted,
+                CallbackRequired = hr.CallbackRequired,
+                CaseNotes = hr.CaseNotes.ToCaseNotesString(),
+                AdviceNotes = hr.AdviceNotes,
+                HelpNeeded = hr.HelpNeeded,
+                NhsCtasId = hr.NhsCtasId,
+                AssignedTo = hr.AssignedTo,
+                HelpRequestCalls = hr.HelpRequestCalls.ToDomain()
+            };
+
+        }
+
+    }
+}


### PR DESCRIPTION
# What
-Add case notes as part of the help request response

# Why
- Call handlers need an overview of case notes attached to a case

# Screenshots
N/A

# Link to ticket
https://trello.com/c/7U4eOykz/30-as-a-call-handler-i-need-to-be-able-to-see-case-notes-for-a-resident-in-the-here-to-help-tool

# Notes

Although case notes is a sub resource, it does not have its own endpoint because case notes are only needed when they are attached to a help request. Help-request requests where case notes are not required is only made once in the tool(search page), therefore a decision was made not to add a separate endpoint for a case note and instead add it to the response of a help-request request.
