### PR TITLE
Expose Casenotes as part of the HelpRequest response

### DIFF
--- a/cv19ResSupportV3.Tests/V3/E2ETests/CreateHelpRequest.cs
+++ b/cv19ResSupportV3.Tests/V3/E2ETests/CreateHelpRequest.cs
@@ -80,9 +80,9 @@ namespace cv19ResSupportV3.Tests.V3.E2ETests
             residentEntity.Uprn.Should().BeEquivalentTo(requestObject.Uprn);
             residentEntity.AddressFirstLine.Should().BeEquivalentTo(requestObject.AddressFirstLine);
             residentEntity.ContactMobileNumber.Should()
-                .BeEquivalentTo(existingResident.ContactMobileNumber + "/" + requestObject.ContactMobileNumber);
+                .BeEquivalentTo(existingResident.ContactMobileNumber + " / " + requestObject.ContactMobileNumber);
             residentEntity.ContactTelephoneNumber.Should()
-                .BeEquivalentTo(existingResident.ContactTelephoneNumber + "/" + requestObject.ContactTelephoneNumber);
+                .BeEquivalentTo(existingResident.ContactTelephoneNumber + " / " + requestObject.ContactTelephoneNumber);
             helpRequestEntity.HelpWithAccessingSupermarketFood.Should().Be(requestObject.HelpWithAccessingSupermarketFood);
             helpRequestEntity.HelpWithCompletingNssForm.Should().Be(requestObject.HelpWithCompletingNssForm);
             helpRequestEntity.HelpWithShieldingGuidance.Should().Be(requestObject.HelpWithShieldingGuidance);

--- a/cv19ResSupportV3.Tests/V3/UseCase/CreateResidentUseCaseTest.cs
+++ b/cv19ResSupportV3.Tests/V3/UseCase/CreateResidentUseCaseTest.cs
@@ -81,5 +81,109 @@ namespace cv19ResSupportV3.Tests.V3.UseCase
             _mockGateway.Verify(m => m.PatchResident(It.IsAny<int>(), It.IsAny<PatchResident>()), Times.Once());
             response.Should().Be(updatedResident);
         }
+        [Test]
+        public void DoesntConcatSameNumbers()
+        {
+            _residentDomain.ContactTelephoneNumber = "123";
+            _residentDomain.ContactMobileNumber = "456";
+            _createResidentCommand.ContactTelephoneNumber = "123";
+            _createResidentCommand.ContactMobileNumber = "456";
+
+            var updatedResident = _residentDomain;
+
+            _mockGateway.Setup(s => s.FindResident(It.IsAny<FindResident>())).Returns(1);
+            _mockGateway.Setup(s => s.GetResident(It.IsAny<int>())).Returns(_residentDomain);
+            _mockGateway.Setup(s => s.PatchResident(It.IsAny<int>(), It.IsAny<PatchResident>())).Returns(updatedResident);
+
+            var response = _classUnderTest.Execute(_createResidentCommand);
+
+            _mockGateway.Verify(m => m.FindResident(It.IsAny<FindResident>()), Times.Once());
+            _mockGateway.Verify(m => m.GetResident(It.IsAny<int>()), Times.Once());
+            _mockGateway.Verify(m => m.CreateResident(It.IsAny<CreateResident>()), Times.Never());
+            _mockGateway.Verify(m => m.PatchResident(
+                It.IsAny<int>(),
+                It.Is<PatchResident>(
+                    x => x.ContactTelephoneNumber == "123" && x.ContactMobileNumber == "456"
+                )
+            ), Times.Once());
+        }
+        [Test]
+        public void DoesntConcatNullNumbers()
+        {
+            _residentDomain.ContactTelephoneNumber = "123";
+            _residentDomain.ContactMobileNumber = "456";
+            _createResidentCommand.ContactTelephoneNumber = "";
+            _createResidentCommand.ContactMobileNumber = null;
+
+            var updatedResident = _residentDomain;
+
+            _mockGateway.Setup(s => s.FindResident(It.IsAny<FindResident>())).Returns(1);
+            _mockGateway.Setup(s => s.GetResident(It.IsAny<int>())).Returns(_residentDomain);
+            _mockGateway.Setup(s => s.PatchResident(It.IsAny<int>(), It.IsAny<PatchResident>())).Returns(updatedResident);
+
+            var response = _classUnderTest.Execute(_createResidentCommand);
+
+            _mockGateway.Verify(m => m.FindResident(It.IsAny<FindResident>()), Times.Once());
+            _mockGateway.Verify(m => m.GetResident(It.IsAny<int>()), Times.Once());
+            _mockGateway.Verify(m => m.CreateResident(It.IsAny<CreateResident>()), Times.Never());
+            _mockGateway.Verify(m => m.PatchResident(
+                It.IsAny<int>(),
+                It.Is<PatchResident>(
+                    x => x.ContactTelephoneNumber == "123" && x.ContactMobileNumber == "456"
+                )
+            ), Times.Once());
+        }
+        [Test]
+        public void SavesNewNumbers()
+        {
+            _residentDomain.ContactTelephoneNumber = null;
+            _residentDomain.ContactMobileNumber = "";
+            _createResidentCommand.ContactTelephoneNumber = "123";
+            _createResidentCommand.ContactMobileNumber = "456";
+
+            var updatedResident = _residentDomain;
+
+            _mockGateway.Setup(s => s.FindResident(It.IsAny<FindResident>())).Returns(1);
+            _mockGateway.Setup(s => s.GetResident(It.IsAny<int>())).Returns(_residentDomain);
+            _mockGateway.Setup(s => s.PatchResident(It.IsAny<int>(), It.IsAny<PatchResident>())).Returns(updatedResident);
+
+            var response = _classUnderTest.Execute(_createResidentCommand);
+
+            _mockGateway.Verify(m => m.FindResident(It.IsAny<FindResident>()), Times.Once());
+            _mockGateway.Verify(m => m.GetResident(It.IsAny<int>()), Times.Once());
+            _mockGateway.Verify(m => m.CreateResident(It.IsAny<CreateResident>()), Times.Never());
+            _mockGateway.Verify(m => m.PatchResident(
+                It.IsAny<int>(),
+                It.Is<PatchResident>(
+                    x => x.ContactTelephoneNumber == "123" && x.ContactMobileNumber == "456"
+                )
+            ), Times.Once());
+        }
+        [Test]
+        public void ConcatDifferentNumbers()
+        {
+            _residentDomain.ContactTelephoneNumber = "123";
+            _residentDomain.ContactMobileNumber = "456";
+            _createResidentCommand.ContactTelephoneNumber = "789";
+            _createResidentCommand.ContactMobileNumber = "012";
+
+            var updatedResident = _residentDomain;
+
+            _mockGateway.Setup(s => s.FindResident(It.IsAny<FindResident>())).Returns(1);
+            _mockGateway.Setup(s => s.GetResident(It.IsAny<int>())).Returns(_residentDomain);
+            _mockGateway.Setup(s => s.PatchResident(It.IsAny<int>(), It.IsAny<PatchResident>())).Returns(updatedResident);
+
+            var response = _classUnderTest.Execute(_createResidentCommand);
+
+            _mockGateway.Verify(m => m.FindResident(It.IsAny<FindResident>()), Times.Once());
+            _mockGateway.Verify(m => m.GetResident(It.IsAny<int>()), Times.Once());
+            _mockGateway.Verify(m => m.CreateResident(It.IsAny<CreateResident>()), Times.Never());
+            _mockGateway.Verify(m => m.PatchResident(
+                It.IsAny<int>(),
+                It.Is<PatchResident>(
+                    x => x.ContactTelephoneNumber == "123 / 789" && x.ContactMobileNumber == "456 / 012"
+                )
+            ), Times.Once());
+        }
     }
 }

--- a/cv19ResSupportV3/V3/UseCase/CreateResidentUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/CreateResidentUseCase.cs
@@ -27,14 +27,26 @@ namespace cv19ResSupportV3.V3.UseCase
                 string[] telephoneNumbers = { existingResident.ContactTelephoneNumber, updateResident.ContactTelephoneNumber };
                 string[] mobileNumbers = { existingResident.ContactMobileNumber, updateResident.ContactMobileNumber };
 
-                updateResident.ContactTelephoneNumber = String.Join("/", telephoneNumbers.Where(x => !string.IsNullOrEmpty(x)));
-                updateResident.ContactMobileNumber = String.Join("/", mobileNumbers.Where(x => !string.IsNullOrEmpty(x)));
+                updateResident.ContactTelephoneNumber = ConcatPhoneNumber(existingResident.ContactTelephoneNumber, updateResident.ContactTelephoneNumber);
+                updateResident.ContactMobileNumber = ConcatPhoneNumber(existingResident.ContactMobileNumber,
+                    updateResident.ContactMobileNumber);
                 return _gateway.PatchResident((int) existingResidentId, updateResident);
             }
             var resident = _gateway.CreateResident(command);
             return resident;
         }
 
-
+        private string ConcatPhoneNumber(string existingNumber, string newNumber)
+        {
+            if (string.IsNullOrEmpty(existingNumber))
+            {
+                return newNumber;
+            }
+            else if (string.IsNullOrEmpty(newNumber) || existingNumber.Contains(newNumber))
+            {
+                return existingNumber;
+            }
+            return String.Join(" / ", existingNumber, newNumber);
+        }
     }
 }


### PR DESCRIPTION
# What
-Add case notes as part of the help request response

# Why
-Call handlers need an overview of case notes attached to a help request

# Screenshots
N/A

# Link to ticket
https://trello.com/c/7U4eOykz/30-as-a-call-handler-i-need-to-be-able-to-see-case-notes-for-a-resident-in-the-here-to-help-tool

# Notes
Although case notes is a sub resource, it does not have its own endpoint because case notes are only needed when they are attached to a help request. Help-request requests where case notes are not required is only made once in the tool(search page), therefore a decision was made not to add a separate endpoint for a case note and instead add it to the response of a help-request request.

