### PR TITLE
Add Create CaseNote endpoint

### DIFF
--- a/cv19ResSupportV3.Tests/V4/Controllers/CaseNotesControllerTests.cs
+++ b/cv19ResSupportV3.Tests/V4/Controllers/CaseNotesControllerTests.cs
@@ -1,0 +1,36 @@
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.UseCase.Interfaces;
+using cv19ResSupportV3.V4.Boundary.Requests;
+using cv19ResSupportV3.V4.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.Controllers
+{
+    [TestFixture]
+    public class CaseNotesControllerTests
+    {
+        private CaseNotesController _classUnderTest;
+        private Mock<ICreateCaseNoteUseCase> _createCaseNoteUseCase;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _createCaseNoteUseCase = new Mock<ICreateCaseNoteUseCase>();
+            _classUnderTest = new CaseNotesController(_createCaseNoteUseCase.Object);
+        }
+
+        [Test]
+        public void CreateReturnsResponseWithStatus()
+        {
+            var request = new CreateCaseNoteRequest() {CaseNote = "{\"author\": \"Name\", caseNote: \"note\" }"};
+            _createCaseNoteUseCase.Setup(uc => uc.Execute(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()))
+                .Returns(new ResidentCaseNote(){Id = 1});
+            var response = _classUnderTest.CreateCaseNote(1, 1, request) as CreatedResult;
+            response.StatusCode.Should().Be(201);
+        }
+    }
+}
+

--- a/cv19ResSupportV3.Tests/V4/Controllers/CaseNotesControllerTests.cs
+++ b/cv19ResSupportV3.Tests/V4/Controllers/CaseNotesControllerTests.cs
@@ -25,9 +25,9 @@ namespace cv19ResSupportV3.Tests.V4.Controllers
         [Test]
         public void CreateReturnsResponseWithStatus()
         {
-            var request = new CreateCaseNoteRequest() {CaseNote = "{\"author\": \"Name\", caseNote: \"note\" }"};
+            var request = new CreateCaseNoteRequest() { CaseNote = "{\"author\": \"Name\", caseNote: \"note\" }" };
             _createCaseNoteUseCase.Setup(uc => uc.Execute(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()))
-                .Returns(new ResidentCaseNote(){Id = 1});
+                .Returns(new ResidentCaseNote() { Id = 1 });
             var response = _classUnderTest.CreateCaseNote(1, 1, request) as CreatedResult;
             response.StatusCode.Should().Be(201);
         }

--- a/cv19ResSupportV3.Tests/V4/Controllers/ResidentsControllerTests.cs
+++ b/cv19ResSupportV3.Tests/V4/Controllers/ResidentsControllerTests.cs
@@ -1,6 +1,4 @@
 using AutoFixture;
-using cv19ResSupportV3.V3.Boundary.Requests;
-using cv19ResSupportV3.V3.Domain.Commands;
 using cv19ResSupportV3.V4;
 using cv19ResSupportV3.V4.Controllers;
 using cv19ResSupportV3.V4.Factories;

--- a/cv19ResSupportV3.Tests/V4/E2ETests/CreateCaseNote.cs
+++ b/cv19ResSupportV3.Tests/V4/E2ETests/CreateCaseNote.cs
@@ -32,22 +32,22 @@ namespace cv19ResSupportV3.Tests.V4.E2ETests
             var resident = new Fixture().Build<ResidentEntity>()
                 .Without(re => re.HelpRequests)
                 .Without(re => re.CaseNotes)
-                .With(x => x.Id,residentId)
+                .With(x => x.Id, residentId)
                 .Create();
 
             var helpRequest = new Fixture().Build<HelpRequestEntity>()
                 .Without(hr => hr.ResidentEntity)
                 .Without(hr => hr.HelpRequestCalls)
                 .Without(hr => hr.CaseNotes)
-                .With(x => x.Id,helpRequestId)
-                .With(x => x.ResidentId,residentId)
+                .With(x => x.Id, helpRequestId)
+                .With(x => x.ResidentId, residentId)
                 .Create();
 
             DatabaseContext.ResidentEntities.Add(resident);
             DatabaseContext.HelpRequestEntities.Add(helpRequest);
             DatabaseContext.SaveChanges();
 
-            var caseNote = new CreateCaseNoteRequest() {CaseNote = "Content"};
+            var caseNote = new CreateCaseNoteRequest() { CaseNote = "Content" };
             var data = JsonConvert.SerializeObject(caseNote);
             HttpContent postContent = new StringContent(data, Encoding.UTF8, "application/json");
             var uri = new Uri($"api/v4/residents/1/help-requests/1/case-notes", UriKind.Relative);

--- a/cv19ResSupportV3.Tests/V4/E2ETests/CreateCaseNote.cs
+++ b/cv19ResSupportV3.Tests/V4/E2ETests/CreateCaseNote.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using AutoFixture;
+using cv19ResSupportV3.Tests.V3.E2ETests;
+using cv19ResSupportV3.V3.Infrastructure;
+using cv19ResSupportV3.V4.Boundary.Requests;
+using cv19ResSupportV3.V4.Boundary.Responses;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.E2ETests
+{
+    [TestFixture]
+    public class CreateCaseNote : IntegrationTests<Startup>
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            DatabaseContext.Database.RollbackTransaction();
+            E2ETestHelpers.ClearTable(DatabaseContext);
+        }
+
+        [Test]
+        public async Task CanCreateCaseNotes()
+        {
+            var residentId = 1;
+            var helpRequestId = 1;
+            var resident = new Fixture().Build<ResidentEntity>()
+                .Without(re => re.HelpRequests)
+                .Without(re => re.CaseNotes)
+                .With(x => x.Id,residentId)
+                .Create();
+
+            var helpRequest = new Fixture().Build<HelpRequestEntity>()
+                .Without(hr => hr.ResidentEntity)
+                .Without(hr => hr.HelpRequestCalls)
+                .Without(hr => hr.CaseNotes)
+                .With(x => x.Id,helpRequestId)
+                .With(x => x.ResidentId,residentId)
+                .Create();
+
+            DatabaseContext.ResidentEntities.Add(resident);
+            DatabaseContext.HelpRequestEntities.Add(helpRequest);
+            DatabaseContext.SaveChanges();
+
+            var caseNote = new CreateCaseNoteRequest() {CaseNote = "Content"};
+            var data = JsonConvert.SerializeObject(caseNote);
+            HttpContent postContent = new StringContent(data, Encoding.UTF8, "application/json");
+            var uri = new Uri($"api/v4/residents/1/help-requests/1/case-notes", UriKind.Relative);
+            var response = Client.PostAsync(uri, postContent);
+            postContent.Dispose();
+            var statusCode = response.Result.StatusCode;
+            statusCode.Should().Be(201);
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<CaseNoteResponse>(stringContent);
+            var caseNoteEntity = DatabaseContext.CaseNoteEntities.FirstOrDefault(x => x.HelpRequestId == helpRequestId);
+            convertedResponse.CaseNote.Should().Be(caseNoteEntity.CaseNote);
+            caseNote.CaseNote.Should().Be(caseNoteEntity.CaseNote);
+        }
+    }
+}

--- a/cv19ResSupportV3/V4/Boundary/Requests/CreateCaseNoteRequest.cs
+++ b/cv19ResSupportV3/V4/Boundary/Requests/CreateCaseNoteRequest.cs
@@ -1,0 +1,7 @@
+namespace cv19ResSupportV3.V4.Boundary.Requests
+{
+    public class CreateCaseNoteRequest
+    {
+        public string CaseNote { get; set; }
+    }
+}

--- a/cv19ResSupportV3/V4/Boundary/Responses/CaseNoteResponse.cs
+++ b/cv19ResSupportV3/V4/Boundary/Responses/CaseNoteResponse.cs
@@ -1,0 +1,10 @@
+namespace cv19ResSupportV3.V4.Boundary.Responses
+{
+    public class CaseNoteResponse
+    {
+    public int Id { get; set; }
+        public int ResidentId { get; set; }
+        public int HelpRequestId { get; set; }
+        public string CaseNote { get; set; }
+    }
+}

--- a/cv19ResSupportV3/V4/Boundary/Responses/CaseNoteResponse.cs
+++ b/cv19ResSupportV3/V4/Boundary/Responses/CaseNoteResponse.cs
@@ -2,7 +2,7 @@ namespace cv19ResSupportV3.V4.Boundary.Responses
 {
     public class CaseNoteResponse
     {
-    public int Id { get; set; }
+        public int Id { get; set; }
         public int ResidentId { get; set; }
         public int HelpRequestId { get; set; }
         public string CaseNote { get; set; }

--- a/cv19ResSupportV3/V4/Controllers/CaseNotesController.cs
+++ b/cv19ResSupportV3/V4/Controllers/CaseNotesController.cs
@@ -1,0 +1,40 @@
+using System;
+using cv19ResSupportV3.V3.Controllers;
+using cv19ResSupportV3.V3.UseCase.Interfaces;
+using cv19ResSupportV3.V4.Boundary.Requests;
+using cv19ResSupportV3.V4.Boundary.Responses;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace cv19ResSupportV3.V4.Controllers
+{
+
+    [ApiController]
+    [Route("api/v4/residents/{id}/help-requests/{help-request-id}/case-notes")]
+    [Produces("application/json")]
+    // Check service api version information
+    [ApiVersion("3.0")]
+
+    public class CaseNotesController : BaseController
+    {
+        private readonly ICreateCaseNoteUseCase _addCaseNoteUseCase;
+
+        public CaseNotesController(ICreateCaseNoteUseCase addCaseNoteUseCase)
+        {
+            _addCaseNoteUseCase = addCaseNoteUseCase;
+        }
+
+
+        /// <summary>
+        /// Creates a resident help request with the values provided.
+        /// </summary>
+        /// <response code="201">...</response>
+        [ProducesResponseType(typeof(CaseNoteResponse), StatusCodes.Status201Created)]
+        [HttpPost]
+        public IActionResult CreateCaseNote([FromRoute(Name = "id")] int residentId, [FromRoute(Name = "help-request-id")] int helpRequestId, [FromBody] CreateCaseNoteRequest caseNote)
+        {
+            var response = _addCaseNoteUseCase.Execute(residentId, helpRequestId, caseNote.CaseNote);
+            return Created(new Uri($"api/v4/residents/{residentId}/help-requests/{helpRequestId}/case-notes/{response}", UriKind.Relative), response);
+        }
+    }
+}


### PR DESCRIPTION
# What
Add create case note for a help request endpoint: POST `/api/v4/residents/1/help-requests/1/case-notes`
It takes in a JSON object containing CaseNote:
`{"CaseNote": "{\"author\":\"Test\",\"noteDate\":\"Tue, 08 Sep 2020 10:15:52 GMT\",\"note\":\"*** TESTED ***\"}"}`

CaseNote should be a JSON string containing author, noteDate, note and helpNeeded.

# Why
To create a new entry for each newly added case note

# Screenshots
N/A

# Link to ticket
https://trello.com/c/rWjYqGL2/40-as-a-call-handler-i-need-to-be-able-to-record-case-notes-from-a-call


# Notes
Might need to add another create endpoint if we want to create case notes for a resident and not a help request