### PR TITLE
Get case notes by resident

### DIFF
--- a/cv19ResSupportV3.Tests/V3/Gateways/CaseNotesGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/CaseNotesGatewayTest.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using AutoFixture;
 using cv19ResSupportV3.Tests.V3.Helpers;
 using cv19ResSupportV3.V3.Gateways;
 using cv19ResSupportV3.V3.Infrastructure;
@@ -11,6 +13,7 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
     public class CaseNotesGatewayTest : DatabaseTests
     {
         private CaseNotesGateway _classUnderTest;
+        Fixture _fixture = new Fixture();
 
         [SetUp]
         public void Setup()
@@ -81,5 +84,42 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
         }
 
 
+        [Test]
+        public void GetByResidentIdReturnsCorrectCaseNotes()
+        {
+            var resident = EntityHelpers.createResident(115);
+            var residentTwo = EntityHelpers.createResident(118);
+            var helpRequest = EntityHelpers.createHelpRequestEntity(45, resident.Id);
+            var helpRequestTwo = EntityHelpers.createHelpRequestEntity(44, residentTwo.Id);
+
+            var caseNote = new CaseNoteEntity() { CaseNote = "before update", ResidentId = resident.Id, HelpRequestId = helpRequest.Id };
+
+            var caseNotes = _fixture.Build<CaseNoteEntity>()
+                                                       .With(x => x.ResidentId, resident.Id)
+                                                       .Without(x => x.ResidentEntity)
+                                                       .Without(x => x.HelpRequestEntity)
+                                                       .With(x => x.HelpRequestId, helpRequest.Id)
+                                                       .CreateMany().ToList();
+            var caseNotesTwo = _fixture.Build<CaseNoteEntity>()
+                                                        .With(x => x.ResidentId, residentTwo.Id)                                                        .With(x => x.ResidentId, residentTwo.Id)
+                                                        .Without(x => x.ResidentEntity)
+                                                        .Without(x => x.HelpRequestEntity)
+                                                        .With(x => x.HelpRequestId, helpRequestTwo.Id)
+                                                        .CreateMany().ToList();
+
+            DatabaseContext.ResidentEntities.AddRange(resident,residentTwo);
+            DatabaseContext.HelpRequestEntities.AddRange(helpRequest, helpRequestTwo);
+            DatabaseContext.CaseNoteEntities.AddRange(caseNotes);
+            DatabaseContext.CaseNoteEntities.AddRange(caseNotesTwo);
+            DatabaseContext.SaveChanges();
+
+            _classUnderTest.UpdateCaseNote(helpRequest.Id, resident.Id, "after update");
+
+            var caseNotesResult = _classUnderTest.GetByResidentId(resident.Id);
+            var caseNotesResultTwo = _classUnderTest.GetByResidentId(resident.Id);
+
+            caseNotesResult.Count.Should().Be(caseNotes.Count);
+            caseNotesResultTwo.Count.Should().Be(caseNotesTwo.Count);
+        }
     }
 }

--- a/cv19ResSupportV3.Tests/V3/Gateways/CaseNotesGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/CaseNotesGatewayTest.cs
@@ -101,13 +101,13 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
                                                        .With(x => x.HelpRequestId, helpRequest.Id)
                                                        .CreateMany().ToList();
             var caseNotesTwo = _fixture.Build<CaseNoteEntity>()
-                                                        .With(x => x.ResidentId, residentTwo.Id)                                                        .With(x => x.ResidentId, residentTwo.Id)
+                                                        .With(x => x.ResidentId, residentTwo.Id).With(x => x.ResidentId, residentTwo.Id)
                                                         .Without(x => x.ResidentEntity)
                                                         .Without(x => x.HelpRequestEntity)
                                                         .With(x => x.HelpRequestId, helpRequestTwo.Id)
                                                         .CreateMany().ToList();
 
-            DatabaseContext.ResidentEntities.AddRange(resident,residentTwo);
+            DatabaseContext.ResidentEntities.AddRange(resident, residentTwo);
             DatabaseContext.HelpRequestEntities.AddRange(helpRequest, helpRequestTwo);
             DatabaseContext.CaseNoteEntities.AddRange(caseNotes);
             DatabaseContext.CaseNoteEntities.AddRange(caseNotesTwo);

--- a/cv19ResSupportV3.Tests/V4/Controllers/CaseNotesControllerTests.cs
+++ b/cv19ResSupportV3.Tests/V4/Controllers/CaseNotesControllerTests.cs
@@ -29,9 +29,9 @@ namespace cv19ResSupportV3.Tests.V4.Controllers
         [Test]
         public void CreateReturnsResponseWithStatus()
         {
-            var request = new CreateCaseNoteRequest() {CaseNote = "{\"author\": \"Name\", caseNote: \"note\" }"};
+            var request = new CreateCaseNoteRequest() { CaseNote = "{\"author\": \"Name\", caseNote: \"note\" }" };
             _createCaseNoteUseCase.Setup(uc => uc.Execute(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()))
-                .Returns(new ResidentCaseNote() {Id = 1});
+                .Returns(new ResidentCaseNote() { Id = 1 });
             var response = _classUnderTest.CreateCaseNote(1, 1, request) as CreatedResult;
             response.StatusCode.Should().Be(201);
         }
@@ -40,7 +40,7 @@ namespace cv19ResSupportV3.Tests.V4.Controllers
         public void GetByResidentIdReturnsResponseWithStatus()
         {
             _getCaseNotesByResidentIdUseCase.Setup(uc => uc.Execute(It.IsAny<int>()))
-                .Returns(new List<ResidentCaseNote>() { new ResidentCaseNote() {Id = 1} });
+                .Returns(new List<ResidentCaseNote>() { new ResidentCaseNote() { Id = 1 } });
             var response = _classUnderTest.GetCaseNotesByResidentId(1) as OkObjectResult;
             response.StatusCode.Should().Be(200);
         }

--- a/cv19ResSupportV3.Tests/V4/Controllers/CaseNotesControllerTests.cs
+++ b/cv19ResSupportV3.Tests/V4/Controllers/CaseNotesControllerTests.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using cv19ResSupportV3.V3.Domain;
 using cv19ResSupportV3.V3.UseCase.Interfaces;
 using cv19ResSupportV3.V4.Boundary.Requests;
 using cv19ResSupportV3.V4.Controllers;
+using cv19ResSupportV3.V4.UseCase.Interface;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
@@ -14,22 +16,33 @@ namespace cv19ResSupportV3.Tests.V4.Controllers
     {
         private CaseNotesController _classUnderTest;
         private Mock<ICreateCaseNoteUseCase> _createCaseNoteUseCase;
+        private Mock<IGetCaseNotesByResidentId> _getCaseNotesByResidentIdUseCase;
 
         [SetUp]
         public void SetUp()
         {
             _createCaseNoteUseCase = new Mock<ICreateCaseNoteUseCase>();
-            _classUnderTest = new CaseNotesController(_createCaseNoteUseCase.Object);
+            _getCaseNotesByResidentIdUseCase = new Mock<IGetCaseNotesByResidentId>();
+            _classUnderTest = new CaseNotesController(_createCaseNoteUseCase.Object, _getCaseNotesByResidentIdUseCase.Object);
         }
 
         [Test]
         public void CreateReturnsResponseWithStatus()
         {
-            var request = new CreateCaseNoteRequest() { CaseNote = "{\"author\": \"Name\", caseNote: \"note\" }" };
+            var request = new CreateCaseNoteRequest() {CaseNote = "{\"author\": \"Name\", caseNote: \"note\" }"};
             _createCaseNoteUseCase.Setup(uc => uc.Execute(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()))
-                .Returns(new ResidentCaseNote() { Id = 1 });
+                .Returns(new ResidentCaseNote() {Id = 1});
             var response = _classUnderTest.CreateCaseNote(1, 1, request) as CreatedResult;
             response.StatusCode.Should().Be(201);
+        }
+
+        [Test]
+        public void GetByResidentIdReturnsResponseWithStatus()
+        {
+            _getCaseNotesByResidentIdUseCase.Setup(uc => uc.Execute(It.IsAny<int>()))
+                .Returns(new List<ResidentCaseNote>() { new ResidentCaseNote() {Id = 1} });
+            var response = _classUnderTest.GetCaseNotesByResidentId(1) as OkObjectResult;
+            response.StatusCode.Should().Be(200);
         }
     }
 }

--- a/cv19ResSupportV3.Tests/V4/E2ETests/GetCaseNotesByResidentId.cs
+++ b/cv19ResSupportV3.Tests/V4/E2ETests/GetCaseNotesByResidentId.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture;
+using cv19ResSupportV3.Tests.V3.E2ETests;
+using cv19ResSupportV3.V3.Infrastructure;
+using cv19ResSupportV3.V4.Boundary.Responses;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.E2ETests
+{
+    [TestFixture]
+    public class GetCaseNotesByResidentId : IntegrationTests<Startup>
+    {
+        Fixture _fixture = new Fixture();
+
+        [SetUp]
+        public void SetUp()
+        {
+            DatabaseContext.Database.RollbackTransaction();
+            E2ETestHelpers.ClearTable(DatabaseContext);
+        }
+
+        [Test]
+        public async Task CreateResidentRequestCreatesRecord()
+        {
+            var resident = _fixture.Build<ResidentEntity>()
+                .Without(re => re.HelpRequests)
+                .Without(re => re.CaseNotes)
+                .Create();
+
+            var helpRequest = _fixture.Build<HelpRequestEntity>()
+                .Without(hr => hr.ResidentEntity)
+                .Without(hr => hr.CaseNotes)
+                .Without(hr => hr.HelpRequestCalls)
+                .With(hr => hr.ResidentId, resident.Id)
+                .Create();
+
+            var caseNotes = _fixture.Build<CaseNoteEntity>()
+                .With(x => x.ResidentId, resident.Id)
+                .Without(x => x.ResidentEntity)
+                .Without(x => x.HelpRequestEntity)
+                .With(x => x.HelpRequestId, helpRequest.Id)
+                .CreateMany().ToList();
+            DatabaseContext.ResidentEntities.Add(resident);
+            DatabaseContext.HelpRequestEntities.Add(helpRequest);
+            DatabaseContext.CaseNoteEntities.AddRange(caseNotes);
+            DatabaseContext.SaveChanges();
+
+            var uri = new Uri($"api/v4/residents/{resident.Id}/case-notes", UriKind.Relative);
+            var response = Client.GetAsync(uri);
+            var statusCode = response.Result.StatusCode;
+            statusCode.Should().Be(200);
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<List<CaseNoteResponse>>(stringContent);
+            convertedResponse.Count.Should().Be(caseNotes.Count);
+        }
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/Factories/CaseNotesFactoryTest.cs
+++ b/cv19ResSupportV3.Tests/V4/Factories/CaseNotesFactoryTest.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using AutoFixture;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V4.Factories;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.Factories
+{
+    [TestFixture]
+    public class CaseNotesFactoryTest
+    {
+        Fixture _fixture = new Fixture();
+
+        [Test]
+        public void CanMapADomainToAResponseObject()
+        {
+            var domain = _fixture.Build<ResidentCaseNote>().Create();
+            var response = domain.ToResponse();
+            response.Should().BeEquivalentTo(domain);
+        }
+
+        [Test]
+        public void CanMapADomainListToAResponseList()
+        {
+            var domain = _fixture.Build<ResidentCaseNote>().CreateMany().ToList();
+            var response = domain.ToResponse();
+            response.Should().BeEquivalentTo(domain);
+        }
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/UseCases/GetCaseNotesByResidentIdUseCaseTests.cs
+++ b/cv19ResSupportV3.Tests/V4/UseCases/GetCaseNotesByResidentIdUseCaseTests.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using AutoFixture;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V4.Factories;
+using cv19ResSupportV3.V4.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.UseCases
+{
+    [TestFixture]
+    public class GetCaseNotesByResidentIdUseCaseTests
+    {
+        private Mock<ICaseNotesGateway> _mockGateway;
+        private GetCaseNotesByResidentIdUseCase _classUnderTest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockGateway = new Mock<ICaseNotesGateway>();
+            _classUnderTest = new GetCaseNotesByResidentIdUseCase(_mockGateway.Object);
+        }
+
+        [Test]
+        public void ExecuteMethodCallsResidentGateway()
+        {
+            var gatewayResponse = new Fixture().Build<ResidentCaseNote>().CreateMany().ToList();
+            _mockGateway.Setup(gw => gw.GetByResidentId(It.IsAny<int>())).Returns(gatewayResponse);
+            var response = _classUnderTest.Execute(1);
+            _mockGateway.Verify(uc => uc.GetByResidentId(1), Times.Once);
+            response.Should().BeEquivalentTo(gatewayResponse.ToResponse());
+        }
+
+    }
+}

--- a/cv19ResSupportV3/Startup.cs
+++ b/cv19ResSupportV3/Startup.cs
@@ -175,6 +175,7 @@ namespace cv19ResSupportV3
             services.AddScoped<IGetResidentHelpRequestUseCase, GetResidentHelpRequestUseCase>();
             services.AddScoped<ICreateResidentHelpRequestUseCase, CreateResidentHelpRequestUseCase>();
             services.AddScoped<IPatchResidentHelpRequestUseCase, PatchResidentHelpRequestUseCase>();
+            services.AddScoped<IGetCaseNotesByResidentId, GetCaseNotesByResidentIdUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/cv19ResSupportV3/V3/Gateways/CaseNotesGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/CaseNotesGateway.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Amazon.Lambda.Core;
 using cv19ResSupportV3.V3.Domain;
@@ -92,6 +93,20 @@ namespace cv19ResSupportV3.V3.Gateways
             catch (Exception e)
             {
                 LambdaLogger.Log("PatchCaseNote error: ");
+                LambdaLogger.Log(e.Message);
+                throw;
+            }
+        }
+
+        public List<ResidentCaseNote> GetByResidentId(int residentId)
+        {
+            try
+            {
+                return _helpRequestsContext.CaseNoteEntities.Where(x => x.ResidentId == residentId).ToList().ToDomain();
+            }
+            catch (Exception e)
+            {
+                LambdaLogger.Log("GetByResidentId error: ");
                 LambdaLogger.Log(e.Message);
                 throw;
             }

--- a/cv19ResSupportV3/V3/Gateways/ICaseNotesGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ICaseNotesGateway.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 using cv19ResSupportV3.V3.Domain;
-using cv19ResSupportV3.V3.Domain.Commands;
-using cv19ResSupportV3.V3.Domain.Queries;
 
 namespace cv19ResSupportV3.V3.Gateways
 {
@@ -10,5 +8,6 @@ namespace cv19ResSupportV3.V3.Gateways
         ResidentCaseNote PatchCaseNote(int helpRequestId, int residentId, string caseNote);
         ResidentCaseNote CreateCaseNote(int helpRequestId, int residentId, string caseNote);
         ResidentCaseNote UpdateCaseNote(int helpRequestId, int residentId, string caseNote);
+        List<ResidentCaseNote> GetByResidentId(int residentId);
     }
 }

--- a/cv19ResSupportV3/V4/Boundary/Responses/CaseNoteResponse.cs
+++ b/cv19ResSupportV3/V4/Boundary/Responses/CaseNoteResponse.cs
@@ -3,8 +3,8 @@ namespace cv19ResSupportV3.V4.Boundary.Responses
     public class CaseNoteResponse
     {
         public int Id { get; set; }
-        public int ResidentId { get; set; }
-        public int HelpRequestId { get; set; }
-        public string CaseNote { get; set; }
+            public int ResidentId { get; set; }
+            public int HelpRequestId { get; set; }
+            public string CaseNote { get; set; }
     }
 }

--- a/cv19ResSupportV3/V4/Boundary/Responses/CaseNoteResponse.cs
+++ b/cv19ResSupportV3/V4/Boundary/Responses/CaseNoteResponse.cs
@@ -3,8 +3,8 @@ namespace cv19ResSupportV3.V4.Boundary.Responses
     public class CaseNoteResponse
     {
         public int Id { get; set; }
-            public int ResidentId { get; set; }
-            public int HelpRequestId { get; set; }
-            public string CaseNote { get; set; }
+        public int ResidentId { get; set; }
+        public int HelpRequestId { get; set; }
+        public string CaseNote { get; set; }
     }
 }

--- a/cv19ResSupportV3/V4/Factories/CaseNotesFactory.cs
+++ b/cv19ResSupportV3/V4/Factories/CaseNotesFactory.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V4.Boundary.Responses;
+
+namespace cv19ResSupportV3.V4.Factories
+{
+    public static class CaseNotesFactory
+    {
+        public static CaseNoteResponse ToResponse(this ResidentCaseNote note)
+        {
+            return note == null
+                ? null
+                : new CaseNoteResponse()
+                {
+                    Id = note.Id,
+                    HelpRequestId = note.HelpRequestId,
+                    ResidentId = note.ResidentId,
+                    CaseNote = note.CaseNote
+                };
+        }
+
+        public static List<CaseNoteResponse> ToResponse(this ICollection<ResidentCaseNote> notes)
+        {
+            return notes?.Select(n => n.ToResponse()).ToList();
+        }
+
+    }
+}

--- a/cv19ResSupportV3/V4/UseCase/GetCaseNotesByResidentIdUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/GetCaseNotesByResidentIdUseCase.cs
@@ -5,7 +5,7 @@ using cv19ResSupportV3.V4.UseCase.Interface;
 
 namespace cv19ResSupportV3.V4.UseCase
 {
-    public class GetCaseNotesByResidentIdUseCase :IGetCaseNotesByResidentId
+    public class GetCaseNotesByResidentIdUseCase : IGetCaseNotesByResidentId
     {
         private readonly ICaseNotesGateway _gateway;
 

--- a/cv19ResSupportV3/V4/UseCase/GetCaseNotesByResidentIdUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/GetCaseNotesByResidentIdUseCase.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V4.UseCase.Interface;
+
+namespace cv19ResSupportV3.V4.UseCase
+{
+    public class GetCaseNotesByResidentIdUseCase :IGetCaseNotesByResidentId
+    {
+        private readonly ICaseNotesGateway _gateway;
+
+        public GetCaseNotesByResidentIdUseCase(ICaseNotesGateway gateway)
+        {
+            _gateway = gateway;
+        }
+        public List<ResidentCaseNote> Execute(int id)
+        {
+            return _gateway.GetByResidentId(id);
+        }
+    }
+}

--- a/cv19ResSupportV3/V4/UseCase/Interface/IGetCaseNotesByResidentId.cs
+++ b/cv19ResSupportV3/V4/UseCase/Interface/IGetCaseNotesByResidentId.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using cv19ResSupportV3.V3.Domain;
+
+namespace cv19ResSupportV3.V4.UseCase.Interface
+{
+    public interface IGetCaseNotesByResidentId
+    {
+        List<ResidentCaseNote> Execute(int id);
+    }
+}


### PR DESCRIPTION
# What
Add get endpoint for resident case notes: GET `/api/v4/residents/{id}/case-notes`

It returns a list of case note objects that look like this:
`{
        "Id": 2,
        "ResidentId": 1,
        "HelpRequestId": 1,
        "CaseNote": "content"
}`

CaseNote content currently gets stored in 3 different ways:
1. Old JSON string (one entry contains an array of case notes), for example:
`{"CaseNote": "[
{\"author\":\"Author\",\"noteDate\":\"Tue, 08 Sep 2020 10:15:52 GMT\",\"note\":\"*** TEST ***\"}"}, {\"author\":\"Author\",\"noteDate\":\"Tue, 08 Sep 2020 10:15:52 GMT\",\"note\":\"*** TEST ***\"}"}]`

2. Old non JSON string (one entry can contain multiple notes separated by dashes (--)), for example:
`{ "CaseNote": "Joe Bloggs : Tue, 19 Jan 2021 16:12:22 GMT\n------------\nSome additional case note\n------\n\n\nsmt"}`

3. And the most recent version of JSON string (Which only contains information about 1 case note), the format is not enforced by the API (as it's just a string), but it is expected to be stored like this:
`{"CaseNote": "{\"author\":\"Author\",\"noteDate\":\"Tue, 08 Sep 2020 10:15:52 GMT\",\"note\":\"*** TEST ***\"}"}`

# Why
To provide a new endpoint for getting all the case note entries for a resident, to be used by the new UI.


