### PR TITLE
Get case notes by help request

### DIFF
--- a/cv19ResSupportV3.Tests/V3/Gateways/CaseNotesGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/CaseNotesGatewayTest.cs
@@ -121,5 +121,39 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             caseNotesResult.Count.Should().Be(caseNotes.Count);
             caseNotesResultTwo.Count.Should().Be(caseNotesTwo.Count);
         }
+
+
+        [Test]
+        public void GetByHelpRequestIdReturnsCorrectCaseNotes()
+        {
+            var resident = EntityHelpers.createResident(116);
+            var helpRequest = EntityHelpers.createHelpRequestEntity(46, resident.Id);
+            var helpRequestTwo = EntityHelpers.createHelpRequestEntity(47, resident.Id);
+
+            var caseNotes = _fixture.Build<CaseNoteEntity>()
+                                                       .With(x => x.ResidentId, resident.Id)
+                                                       .Without(x => x.ResidentEntity)
+                                                       .Without(x => x.HelpRequestEntity)
+                                                       .With(x => x.HelpRequestId, helpRequest.Id)
+                                                       .CreateMany().ToList();
+            var caseNotesTwo = _fixture.Build<CaseNoteEntity>()
+                                                        .With(x => x.ResidentId, resident.Id).With(x => x.ResidentId, resident.Id)
+                                                        .Without(x => x.ResidentEntity)
+                                                        .Without(x => x.HelpRequestEntity)
+                                                        .With(x => x.HelpRequestId, helpRequestTwo.Id)
+                                                        .CreateMany().ToList();
+
+            DatabaseContext.ResidentEntities.Add(resident);
+            DatabaseContext.HelpRequestEntities.AddRange(helpRequest, helpRequestTwo);
+            DatabaseContext.CaseNoteEntities.AddRange(caseNotes);
+            DatabaseContext.CaseNoteEntities.AddRange(caseNotesTwo);
+            DatabaseContext.SaveChanges();
+
+            var caseNotesResult = _classUnderTest.GetByHelpRequestId(helpRequest.Id);
+            var caseNotesResultTwo = _classUnderTest.GetByHelpRequestId(helpRequestTwo.Id);
+
+            caseNotesResult.Count.Should().Be(caseNotes.Count);
+            caseNotesResultTwo.Count.Should().Be(caseNotesTwo.Count);
+        }
     }
 }

--- a/cv19ResSupportV3.Tests/V4/Controllers/CaseNotesControllerTests.cs
+++ b/cv19ResSupportV3.Tests/V4/Controllers/CaseNotesControllerTests.cs
@@ -16,14 +16,16 @@ namespace cv19ResSupportV3.Tests.V4.Controllers
     {
         private CaseNotesController _classUnderTest;
         private Mock<ICreateCaseNoteUseCase> _createCaseNoteUseCase;
-        private Mock<IGetCaseNotesByResidentId> _getCaseNotesByResidentIdUseCase;
+        private Mock<IGetCaseNotesByResidentIdUseCase> _getCaseNotesByResidentIdUseCase;
+        private Mock<IGetCaseNotesByHelpRequestIdUseCase> _getCaseNotesByHelpRequestIdUseCase;
 
         [SetUp]
         public void SetUp()
         {
             _createCaseNoteUseCase = new Mock<ICreateCaseNoteUseCase>();
-            _getCaseNotesByResidentIdUseCase = new Mock<IGetCaseNotesByResidentId>();
-            _classUnderTest = new CaseNotesController(_createCaseNoteUseCase.Object, _getCaseNotesByResidentIdUseCase.Object);
+            _getCaseNotesByResidentIdUseCase = new Mock<IGetCaseNotesByResidentIdUseCase>();
+            _getCaseNotesByHelpRequestIdUseCase = new Mock<IGetCaseNotesByHelpRequestIdUseCase>();
+            _classUnderTest = new CaseNotesController(_createCaseNoteUseCase.Object, _getCaseNotesByResidentIdUseCase.Object, _getCaseNotesByHelpRequestIdUseCase.Object);
         }
 
         [Test]
@@ -42,6 +44,15 @@ namespace cv19ResSupportV3.Tests.V4.Controllers
             _getCaseNotesByResidentIdUseCase.Setup(uc => uc.Execute(It.IsAny<int>()))
                 .Returns(new List<ResidentCaseNote>() { new ResidentCaseNote() { Id = 1 } });
             var response = _classUnderTest.GetCaseNotesByResidentId(1) as OkObjectResult;
+            response.StatusCode.Should().Be(200);
+        }
+
+        [Test]
+        public void GetByHelpRequestIdReturnsResponseWithStatus()
+        {
+            _getCaseNotesByHelpRequestIdUseCase.Setup(uc => uc.Execute(It.IsAny<int>()))
+                .Returns(new List<ResidentCaseNote>() { new ResidentCaseNote() { Id = 1 } });
+            var response = _classUnderTest.GetCaseNotesByHelpRequestId(1, 1) as OkObjectResult;
             response.StatusCode.Should().Be(200);
         }
     }

--- a/cv19ResSupportV3.Tests/V4/E2ETests/GetCaseNotesByHelpRequestId.cs
+++ b/cv19ResSupportV3.Tests/V4/E2ETests/GetCaseNotesByHelpRequestId.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture;
+using cv19ResSupportV3.Tests.V3.E2ETests;
+using cv19ResSupportV3.V3.Infrastructure;
+using cv19ResSupportV3.V4.Boundary.Responses;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.E2ETests
+{
+    [TestFixture]
+    public class GetCaseNotesByHelpRequestId : IntegrationTests<Startup>
+    {
+        Fixture _fixture = new Fixture();
+
+        [SetUp]
+        public void SetUp()
+        {
+            DatabaseContext.Database.RollbackTransaction();
+            E2ETestHelpers.ClearTable(DatabaseContext);
+        }
+
+        [Test]
+        public async Task GetsCaseNotesByHelpRequestId()
+        {
+            var resident = _fixture.Build<ResidentEntity>()
+                .Without(re => re.HelpRequests)
+                .Without(re => re.CaseNotes)
+                .Create();
+
+            var helpRequest = _fixture.Build<HelpRequestEntity>()
+                .Without(hr => hr.ResidentEntity)
+                .Without(hr => hr.CaseNotes)
+                .Without(hr => hr.HelpRequestCalls)
+                .With(hr => hr.ResidentId, resident.Id)
+                .Create();
+
+            var caseNotes = _fixture.Build<CaseNoteEntity>()
+                .With(x => x.ResidentId, resident.Id)
+                .Without(x => x.ResidentEntity)
+                .Without(x => x.HelpRequestEntity)
+                .With(x => x.HelpRequestId, helpRequest.Id)
+                .CreateMany().ToList();
+            DatabaseContext.ResidentEntities.Add(resident);
+            DatabaseContext.HelpRequestEntities.Add(helpRequest);
+            DatabaseContext.CaseNoteEntities.AddRange(caseNotes);
+            DatabaseContext.SaveChanges();
+
+            var uri = new Uri($"api/v4/residents/{resident.Id}/help-requests/{helpRequest.Id}/case-notes", UriKind.Relative);
+            var response = Client.GetAsync(uri);
+            var statusCode = response.Result.StatusCode;
+            statusCode.Should().Be(200);
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<List<CaseNoteResponse>>(stringContent);
+            convertedResponse.Count.Should().Be(caseNotes.Count);
+        }
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/UseCases/GetCaseNotesByHelpRequestIdUseCaseTests.cs
+++ b/cv19ResSupportV3.Tests/V4/UseCases/GetCaseNotesByHelpRequestIdUseCaseTests.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using AutoFixture;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V4.Factories;
+using cv19ResSupportV3.V4.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.UseCases
+{
+    [TestFixture]
+    public class GetCaseNotesByHelpRequestIdUseCaseTests
+    {
+        private Mock<ICaseNotesGateway> _mockGateway;
+        private GetCaseNotesByHelpRequestIdUseCase _classUnderTest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockGateway = new Mock<ICaseNotesGateway>();
+            _classUnderTest = new GetCaseNotesByHelpRequestIdUseCase(_mockGateway.Object);
+        }
+
+        [Test]
+        public void ExecuteMethodCallsResidentGateway()
+        {
+            var gatewayResponse = new Fixture().Build<ResidentCaseNote>().CreateMany().ToList();
+            _mockGateway.Setup(gw => gw.GetByHelpRequestId(It.IsAny<int>())).Returns(gatewayResponse);
+            var response = _classUnderTest.Execute(1);
+            _mockGateway.Verify(uc => uc.GetByHelpRequestId(1), Times.Once);
+            response.Should().BeEquivalentTo(gatewayResponse.ToResponse());
+        }
+    }
+}

--- a/cv19ResSupportV3/Startup.cs
+++ b/cv19ResSupportV3/Startup.cs
@@ -175,7 +175,8 @@ namespace cv19ResSupportV3
             services.AddScoped<IGetResidentHelpRequestUseCase, GetResidentHelpRequestUseCase>();
             services.AddScoped<ICreateResidentHelpRequestUseCase, CreateResidentHelpRequestUseCase>();
             services.AddScoped<IPatchResidentHelpRequestUseCase, PatchResidentHelpRequestUseCase>();
-            services.AddScoped<IGetCaseNotesByResidentId, GetCaseNotesByResidentIdUseCase>();
+            services.AddScoped<IGetCaseNotesByResidentIdUseCase, GetCaseNotesByResidentIdUseCase>();
+            services.AddScoped<IGetCaseNotesByHelpRequestIdUseCase, GetCaseNotesByHelpRequestIdUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/cv19ResSupportV3/V3/Gateways/CaseNotesGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/CaseNotesGateway.cs
@@ -111,5 +111,19 @@ namespace cv19ResSupportV3.V3.Gateways
                 throw;
             }
         }
+
+        public List<ResidentCaseNote> GetByHelpRequestId(int helpRequestId)
+        {
+            try
+            {
+                return _helpRequestsContext.CaseNoteEntities.Where(x => x.HelpRequestId == helpRequestId).ToList().ToDomain();
+            }
+            catch (Exception e)
+            {
+                LambdaLogger.Log("GetByHelpRequestId error: ");
+                LambdaLogger.Log(e.Message);
+                throw;
+            }
+        }
     }
 }

--- a/cv19ResSupportV3/V3/Gateways/ICaseNotesGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ICaseNotesGateway.cs
@@ -9,5 +9,6 @@ namespace cv19ResSupportV3.V3.Gateways
         ResidentCaseNote CreateCaseNote(int helpRequestId, int residentId, string caseNote);
         ResidentCaseNote UpdateCaseNote(int helpRequestId, int residentId, string caseNote);
         List<ResidentCaseNote> GetByResidentId(int residentId);
+        List<ResidentCaseNote> GetByHelpRequestId(int helpRequestId);
     }
 }

--- a/cv19ResSupportV3/V4/Controllers/CaseNotesController.cs
+++ b/cv19ResSupportV3/V4/Controllers/CaseNotesController.cs
@@ -21,11 +21,13 @@ namespace cv19ResSupportV3.V4.Controllers
     public class CaseNotesController : BaseController
     {
         private readonly ICreateCaseNoteUseCase _addCaseNoteUseCase;
-        private readonly IGetCaseNotesByResidentId _getCaseNotesByResidentId;
+        private readonly IGetCaseNotesByResidentIdUseCase _getCaseNotesByResidentId;
+        private readonly IGetCaseNotesByHelpRequestIdUseCase _getCaseNotesByHelpRequestId;
 
-        public CaseNotesController(ICreateCaseNoteUseCase addCaseNoteUseCase, IGetCaseNotesByResidentId getCaseNotesByResidentId)
+        public CaseNotesController(ICreateCaseNoteUseCase addCaseNoteUseCase, IGetCaseNotesByResidentIdUseCase getCaseNotesByResidentId, IGetCaseNotesByHelpRequestIdUseCase getCaseNotesByHelpRequestId)
         {
             _addCaseNoteUseCase = addCaseNoteUseCase;
+            _getCaseNotesByHelpRequestId = getCaseNotesByHelpRequestId;
             _getCaseNotesByResidentId = getCaseNotesByResidentId;
         }
 
@@ -54,6 +56,19 @@ namespace cv19ResSupportV3.V4.Controllers
         public IActionResult GetCaseNotesByResidentId([FromRoute(Name = "id")] int residentId)
         {
             var response = _getCaseNotesByResidentId.Execute(residentId);
+            return Ok(response.ToResponse());
+        }
+
+        /// <summary>
+        /// Creates a resident help request with the values provided.
+        /// </summary>
+        /// <response code="201">...</response>
+        [ProducesResponseType(typeof(List<CaseNoteResponse>), StatusCodes.Status201Created)]
+        [HttpGet]
+        [Route("help-requests/{help-request-id}/case-notes")]
+        public IActionResult GetCaseNotesByHelpRequestId([FromRoute(Name = "id")] int residentId, [FromRoute(Name = "help-request-id")] int helpRequestId)
+        {
+            var response = _getCaseNotesByHelpRequestId.Execute(helpRequestId);
             return Ok(response.ToResponse());
         }
     }

--- a/cv19ResSupportV3/V4/UseCase/GetCaseNotesByHelpRequestIdUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/GetCaseNotesByHelpRequestIdUseCase.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V4.UseCase.Interface;
+
+namespace cv19ResSupportV3.V4.UseCase
+{
+    public class GetCaseNotesByHelpRequestIdUseCase : IGetCaseNotesByHelpRequestIdUseCase
+    {
+        private readonly ICaseNotesGateway _gateway;
+
+        public GetCaseNotesByHelpRequestIdUseCase(ICaseNotesGateway gateway)
+        {
+            _gateway = gateway;
+        }
+        public List<ResidentCaseNote> Execute(int id)
+        {
+            return _gateway.GetByHelpRequestId(id);
+        }
+    }
+}

--- a/cv19ResSupportV3/V4/UseCase/GetCaseNotesByResidentIdUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/GetCaseNotesByResidentIdUseCase.cs
@@ -5,7 +5,7 @@ using cv19ResSupportV3.V4.UseCase.Interface;
 
 namespace cv19ResSupportV3.V4.UseCase
 {
-    public class GetCaseNotesByResidentIdUseCase : IGetCaseNotesByResidentId
+    public class GetCaseNotesByResidentIdUseCase : IGetCaseNotesByResidentIdUseCase
     {
         private readonly ICaseNotesGateway _gateway;
 

--- a/cv19ResSupportV3/V4/UseCase/Interface/IGetCaseNotesByHelpRequestIdUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/Interface/IGetCaseNotesByHelpRequestIdUseCase.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using cv19ResSupportV3.V3.Domain;
+
+namespace cv19ResSupportV3.V4.UseCase.Interface
+{
+    public interface IGetCaseNotesByHelpRequestIdUseCase
+    {
+        List<ResidentCaseNote> Execute(int id);
+    }
+}

--- a/cv19ResSupportV3/V4/UseCase/Interface/IGetCaseNotesByResidentIdUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/Interface/IGetCaseNotesByResidentIdUseCase.cs
@@ -3,7 +3,7 @@ using cv19ResSupportV3.V3.Domain;
 
 namespace cv19ResSupportV3.V4.UseCase.Interface
 {
-    public interface IGetCaseNotesByResidentId
+    public interface IGetCaseNotesByResidentIdUseCase
     {
         List<ResidentCaseNote> Execute(int id);
     }


### PR DESCRIPTION
# What
Add get endpoint for help request case notes: GET `/api/v4/residents/{id}/help-requests/{help-request-id}/case-notes`

TL;DR works exactly the same as get case notes by resident ID, but for specific case notes

It returns a list of case note objects that look like this:
`{
        "Id": 2,
        "ResidentId": 1,
        "HelpRequestId": 1,
        "CaseNote": "content"
}`

CaseNote content currently gets stored in 3 different ways:
1. Old JSON string (one entry contains an array of case notes), for example:
`{"CaseNote": "[
{\"author\":\"Author\",\"noteDate\":\"Tue, 08 Sep 2020 10:15:52 GMT\",\"note\":\"*** TEST ***\"}"}, {\"author\":\"Author\",\"noteDate\":\"Tue, 08 Sep 2020 10:15:52 GMT\",\"note\":\"*** TEST ***\"}"}]`

2. Old non JSON string (one entry can contain multiple notes separated by dashes (--)), for example:
`{ "CaseNote": "Joe Bloggs : Tue, 19 Jan 2021 16:12:22 GMT\n------------\nSome additional case note\n------\n\n\nsmt"}`

3. And the most recent version of JSON string (Which only contains information about 1 case note), the format is not enforced by the API (as it's just a string), but it is expected to be stored like this:
`{"CaseNote": "{\"author\":\"Author\",\"noteDate\":\"Tue, 08 Sep 2020 10:15:52 GMT\",\"note\":\"*** TEST ***\"}"}`

# Why
To provide a new endpoint for getting all the case note entries for a help request, to be used by the new UI.
