### PR TITLE
Replace V4 create resident Use case with V3

### DIFF
--- a/cv19ResSupportV3.Tests/V4/Controllers/ResidentsControllerTests.cs
+++ b/cv19ResSupportV3.Tests/V4/Controllers/ResidentsControllerTests.cs
@@ -1,13 +1,15 @@
 using AutoFixture;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Domain.Commands;
+using cv19ResSupportV3.V4.UseCase.Interfaces;
 using cv19ResSupportV3.V4;
 using cv19ResSupportV3.V4.Controllers;
-using cv19ResSupportV3.V4.Factories;
 using cv19ResSupportV3.V4.UseCase.Interface;
-using cv19ResSupportV3.V4.UseCase.Interfaces;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NUnit.Framework;
+using ICreateResidentUseCase = cv19ResSupportV3.V3.UseCase.Interfaces.ICreateResidentUseCase;
 
 namespace cv19ResSupportV3.Tests.V4.Controllers
 {
@@ -16,7 +18,7 @@ namespace cv19ResSupportV3.Tests.V4.Controllers
     {
         private ResidentsController _classUnderTest;
         private Mock<IGetResidentsUseCase> _getResidentsUseCase;
-        private Mock<ICreateResidentsUseCase> _createResidentsUseCase;
+        private Mock<ICreateResidentUseCase> _createResidentUseCase;
         private Mock<IPatchResidentUseCase> _patchResidentUseCase;
         private Mock<ISearchResidentsUseCase> _searchResidentUseCase;
 
@@ -24,11 +26,11 @@ namespace cv19ResSupportV3.Tests.V4.Controllers
         public void SetUp()
         {
             _getResidentsUseCase = new Mock<IGetResidentsUseCase>();
-            _createResidentsUseCase = new Mock<ICreateResidentsUseCase>();
+            _createResidentUseCase = new Mock<ICreateResidentUseCase>();
             _patchResidentUseCase = new Mock<IPatchResidentUseCase>();
             _searchResidentUseCase = new Mock<ISearchResidentsUseCase>();
             _classUnderTest = new ResidentsController(
-                _createResidentsUseCase.Object,
+                _createResidentUseCase.Object,
                 _getResidentsUseCase.Object,
                 _patchResidentUseCase.Object,
                 _searchResidentUseCase.Object);
@@ -37,9 +39,9 @@ namespace cv19ResSupportV3.Tests.V4.Controllers
         [Test]
         public void CreateReturnsResponseWithStatus()
         {
-            var request = new Fixture().Build<ResidentRequestBoundary>().Create();
-            _createResidentsUseCase.Setup(uc => uc.Execute(It.IsAny<ResidentRequestBoundary>()))
-                .Returns(request.ToResident().ToResponse);
+            var request = new Fixture().Build<CreateResident>().Create();
+            _createResidentUseCase.Setup(uc => uc.Execute(It.IsAny<CreateResident>()))
+                .Returns(new Resident());
             var response = _classUnderTest.CreateResident(request) as CreatedResult;
             response.StatusCode.Should().Be(201);
         }
@@ -47,11 +49,11 @@ namespace cv19ResSupportV3.Tests.V4.Controllers
         [Test]
         public void CreateResidentCallsCreateResidentUseCaseExecuteMethod()
         {
-            var request = new Fixture().Build<ResidentRequestBoundary>().Create();
-            _createResidentsUseCase.Setup(uc => uc.Execute(It.IsAny<ResidentRequestBoundary>()))
-                .Returns(request.ToResident().ToResponse);
+            var request = new Fixture().Build<CreateResident>().Create();
+            _createResidentUseCase.Setup(uc => uc.Execute(It.IsAny<CreateResident>()))
+                .Returns(new Resident());
             _classUnderTest.CreateResident(request);
-            _createResidentsUseCase.Verify(uc => uc.Execute(It.IsAny<ResidentRequestBoundary>()), Times.Once);
+            _createResidentUseCase.Verify(uc => uc.Execute(It.IsAny<CreateResident>()), Times.Once);
         }
 
         [Test]

--- a/cv19ResSupportV3/Startup.cs
+++ b/cv19ResSupportV3/Startup.cs
@@ -167,7 +167,6 @@ namespace cv19ResSupportV3
             services.AddScoped<ICreateCaseNoteUseCase, CreateCaseNoteUseCase>();
             services.AddScoped<IUpdateCaseNoteUseCase, UpdateCaseNoteUseCase>();
             services.AddScoped<IUpdateStaffAssignmentsUseCase, UpdateStaffAssignmentsUseCase>();
-            services.AddScoped<ICreateResidentsUseCase, CreateResidentsUseCase>();
             services.AddScoped<IGetResidentsUseCase, GetResidentsUseCase>();
             services.AddScoped<ISearchResidentsUseCase, SearchResidentsUseCase>();
             services.AddScoped<V4.UseCase.Interfaces.IPatchResidentUseCase, V4.UseCase.PatchResidentUseCase>();

--- a/cv19ResSupportV3/V4/Controllers/ResidentsController.cs
+++ b/cv19ResSupportV3/V4/Controllers/ResidentsController.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections.Generic;
 using cv19ResSupportV3.V3.Controllers;
 using cv19ResSupportV3.V3.Domain.Commands;
-using cv19ResSupportV3.V4.Boundary.Requests;
 using cv19ResSupportV3.V4.UseCase.Interface;
-using cv19ResSupportV3.V4.UseCase.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using cv19ResSupportV3.V4.UseCase.Interfaces;
+using ICreateResidentUseCase = cv19ResSupportV3.V3.UseCase.Interfaces.ICreateResidentUseCase;
 
 namespace cv19ResSupportV3.V4.Controllers
 {
@@ -18,18 +18,18 @@ namespace cv19ResSupportV3.V4.Controllers
 
     public class ResidentsController : BaseController
     {
-        private readonly ICreateResidentsUseCase _createResidentsUseCase;
+        private readonly ICreateResidentUseCase _createResidentUseCase;
         private readonly IGetResidentsUseCase _getResidentsUseCase;
         private readonly IPatchResidentUseCase _patchResidentsUseCase;
         private readonly ISearchResidentsUseCase _searchResidentsUseCase;
 
         public ResidentsController(
-            ICreateResidentsUseCase createResidentsUseCase,
+            ICreateResidentUseCase createResidentUseCase,
             IGetResidentsUseCase getResidentsUseCase,
             IPatchResidentUseCase patchResidentsUseCase,
             ISearchResidentsUseCase searchResidentsUseCase)
         {
-            _createResidentsUseCase = createResidentsUseCase;
+            _createResidentUseCase = createResidentUseCase;
             _getResidentsUseCase = getResidentsUseCase;
             _patchResidentsUseCase = patchResidentsUseCase;
             _searchResidentsUseCase = searchResidentsUseCase;
@@ -43,9 +43,9 @@ namespace cv19ResSupportV3.V4.Controllers
         /// <response code="400">...</response>
         [ProducesResponseType(typeof(ResidentResponseBoundary), StatusCodes.Status201Created)]
         [HttpPost]
-        public IActionResult CreateResident(ResidentRequestBoundary request)
+        public IActionResult CreateResident(CreateResident request)
         {
-            var response = _createResidentsUseCase.Execute(request);
+            var response = _createResidentUseCase.Execute(request);
             if (response != null)
                 return Created(new Uri($"api/v4/residents/{response.Id}", UriKind.Relative), response);
             return (BadRequest("Resident not created"));


### PR DESCRIPTION
# What
Replace V4 create resident Use case with V3

# Why
Because V4 create resident is not deduplicating residents

# Notes
seems like currently V4 endpoint was only used from the new UI

