### PR TITLE
add the ability to search for HelpRequest by metadata

### DIFF
--- a/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
@@ -9,6 +9,7 @@ using cv19ResSupportV3.V3.Infrastructure;
 using FluentAssertions;
 using LBHFSSPublicAPI.Tests.TestHelpers;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using NUnit.Framework;
 
 namespace cv19ResSupportV3.Tests.V3.Gateways
@@ -301,6 +302,13 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
         public void FindHelpRequestByCtasIdReturnsNullIfItDoesntExist()
         {
             var response = _classUnderTest.FindHelpRequestByCtasId("anything");
+
+            response.Should().BeNull();
+        }
+        [Test]
+        public void FindHelpRequestByMetadaReturnsNullIfItDoesntExist()
+        {
+            var response = _classUnderTest.FindHelpRequestByMetadata("someName", It.IsAny<object>());
 
             response.Should().BeNull();
         }

--- a/cv19ResSupportV3.Tests/V3/UseCase/CreateHelpRequestUseCaseTests.cs
+++ b/cv19ResSupportV3.Tests/V3/UseCase/CreateHelpRequestUseCaseTests.cs
@@ -28,6 +28,7 @@ namespace cv19ResSupportV3.Tests.V3.UseCase
         public void SavesHelpRequestIfItDoesNotExist()
         {
             _mockGateway.Setup(s => s.FindHelpRequestByCtasId(It.IsAny<string>())).Returns<int?>(null);
+            _mockGateway.Setup(s => s.FindHelpRequestByMetadata(It.IsAny<string>(), It.IsAny<string>())).Returns<int?>(null);
             _mockGateway.Setup(s => s.CreateHelpRequest(It.IsAny<int>(), It.IsAny<CreateHelpRequest>())).Returns(1);
 
             var dataToSave = new Fixture().Build<CreateHelpRequest>().Create();
@@ -37,13 +38,29 @@ namespace cv19ResSupportV3.Tests.V3.UseCase
             response.Should().Be(1);
         }
         [Test]
-        public void DoesNotCreateNewHelpRequestIfItDoesExist()
+        public void DoesNotCreateNewHelpRequestIfItDoesExistWithCtasNumber()
         {
             _mockGateway.Setup(s => s.FindHelpRequestByCtasId(It.IsAny<string>())).Returns(1);
+            _mockGateway.Setup(s => s.FindHelpRequestByMetadata(It.IsAny<string>(), It.IsAny<object>())).Returns<int?>(null);
 
             var dataToSave = new Fixture().Build<CreateHelpRequest>().Create();
             var response = _classUnderTest.Execute(1, dataToSave);
             _mockGateway.Verify(m => m.FindHelpRequestByCtasId(It.IsAny<string>()), Times.Once());
+            _mockGateway.Verify(m => m.FindHelpRequestByMetadata(It.IsAny<string>(), It.IsAny<object>()), Times.Never());
+            _mockGateway.Verify(m => m.CreateHelpRequest(It.IsAny<int>(), It.IsAny<CreateHelpRequest>()), Times.Never);
+            response.Should().Be(1);
+        }
+
+        [Test]
+        public void DoesNotCreateNewHelpRequestIfItDoesExistWithMetadata()
+        {
+            _mockGateway.Setup(s => s.FindHelpRequestByCtasId(It.IsAny<string>())).Returns<int?>(null);
+            _mockGateway.Setup(s => s.FindHelpRequestByMetadata(It.IsAny<string>(), It.IsAny<object>())).Returns(1);
+
+            var dataToSave = new Fixture().Build<CreateHelpRequest>().Create();
+            var response = _classUnderTest.Execute(1, dataToSave);
+            _mockGateway.Verify(m => m.FindHelpRequestByCtasId(It.IsAny<string>()), Times.Once());
+            _mockGateway.Verify(m => m.FindHelpRequestByMetadata(It.IsAny<string>(), It.IsAny<object>()), Times.Once());
             _mockGateway.Verify(m => m.CreateHelpRequest(It.IsAny<int>(), It.IsAny<CreateHelpRequest>()), Times.Never);
             response.Should().Be(1);
         }

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -73,12 +73,10 @@ namespace cv19ResSupportV3.V3.Gateways
                 return null;
             };
 
-            var sqlString = $"select * from help_requests WHERE metadata->>'{propertyName}' LIKE '{propertyInfo}'";
-
             try
             {
                 var helpRequestEntity = _helpRequestsContext.HelpRequestEntities
-                    .FromSqlRaw(sqlString)
+                    .FromSqlRaw("select * from help_requests WHERE metadata->>{0} LIKE {1}", propertyName, propertyInfo)
                     .FirstOrDefault();
 
                 return helpRequestEntity?.Id;

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -60,6 +60,36 @@ namespace cv19ResSupportV3.V3.Gateways
                 throw;
             }
         }
+        public int? FindHelpRequestByMetadata(string propertyName, dynamic metadata)
+        {
+            string propertyInfo;
+
+            try
+            {
+                propertyInfo = metadata.GetProperty(propertyName).ToString();
+            }
+            catch (Exception e)
+            {
+                return null;
+            };
+
+            var sqlString = $"select * from help_requests WHERE metadata->>'{propertyName}' LIKE '{propertyInfo}'";
+
+            try
+            {
+                var helpRequestEntity = _helpRequestsContext.HelpRequestEntities
+                    .FromSqlRaw(sqlString)
+                    .FirstOrDefault();
+
+                return helpRequestEntity?.Id;
+            }
+            catch (Exception e)
+            {
+                LambdaLogger.Log("FindHelpRequestByMetadata error: ");
+                LambdaLogger.Log(e.Message);
+                throw;
+            }
+        }
 
         public List<LookupDomain> GetLookups(LookupQuery command)
         {

--- a/cv19ResSupportV3/V3/Gateways/IHelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/IHelpRequestGateway.cs
@@ -9,6 +9,7 @@ namespace cv19ResSupportV3.V3.Gateways
     {
         int CreateHelpRequest(int residentId, CreateHelpRequest command);
         int? FindHelpRequestByCtasId(string ctasId);
+        int? FindHelpRequestByMetadata(string propertyName, dynamic metadata);
         List<LookupDomain> GetLookups(LookupQuery command);
         HelpRequest UpdateHelpRequest(int id, UpdateHelpRequest command);
         HelpRequest PatchHelpRequest(int id, PatchHelpRequest command);

--- a/cv19ResSupportV3/V3/UseCase/CreateHelpRequestUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/CreateHelpRequestUseCase.cs
@@ -16,6 +16,9 @@ namespace cv19ResSupportV3.V3.UseCase
             var helpRequestId = _gateway.FindHelpRequestByCtasId(command.NhsCtasId);
             if (helpRequestId != null) { return (int) helpRequestId; }
 
+            helpRequestId = _gateway.FindHelpRequestByMetadata("nsss_id", command.Metadata);
+            if (helpRequestId != null) { return (int) helpRequestId; }
+
             return _gateway.CreateHelpRequest(residentId, command);
         }
     }


### PR DESCRIPTION
Co-authored-by: Kat <katrina@madetech.com>

# What
to be able to deduplicate records coming in from the national shielding service list we needed a way to search by metadata to know whenever they have already been added.

# Why
so that the data ingestion lambda doesn't keep on adding the same records again and again 

# Screenshots
![Screenshot 2021-02-16 at 15 15 25](https://user-images.githubusercontent.com/8051117/108082253-ce4d9500-7069-11eb-963f-e5ddd03158fe.png)


# Link to ticket
https://trello.com/c/mt9xevV7/38-as-a-call-handler-i-need-to-see-which-cev-cases-i-need-to-call-from-the-national-shielding-service-export

# Notes


