### PR TITLE
Update parameter positions of execute method in the CreateCaseNote controller

### DIFF
--- a/cv19ResSupportV3.Tests/V3/E2ETests/CreateHelpRequest.cs
+++ b/cv19ResSupportV3.Tests/V3/E2ETests/CreateHelpRequest.cs
@@ -6,9 +6,6 @@ using AutoFixture;
 using cv19ResSupportV3.Tests.V3.Helpers;
 using cv19ResSupportV3.V3.Boundary.Response;
 using cv19ResSupportV3.V3.Boundary.Requests;
-using cv19ResSupportV3.V3.Domain;
-using cv19ResSupportV3.V3.Infrastructure;
-using cv19ResSupportV3.V4.Factories;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
@@ -31,8 +28,6 @@ namespace cv19ResSupportV3.Tests.V3.E2ETests
         {
             var requestObject = new Fixture().Create<HelpRequestCreateRequestBoundary>();
             requestObject.CaseNotes = "";
-            Console.WriteLine("requestObject");
-            Console.WriteLine(requestObject);
             var data = JsonConvert.SerializeObject(requestObject);
             HttpContent postContent = new StringContent(data, Encoding.UTF8, "application/json");
             var uri = new Uri($"api/v3/help-requests", UriKind.Relative);

--- a/cv19ResSupportV3.Tests/V3/E2ETests/CreateHelpRequest.cs
+++ b/cv19ResSupportV3.Tests/V3/E2ETests/CreateHelpRequest.cs
@@ -8,6 +8,7 @@ using cv19ResSupportV3.V3.Boundary.Response;
 using cv19ResSupportV3.V3.Boundary.Requests;
 using cv19ResSupportV3.V3.Domain;
 using cv19ResSupportV3.V3.Infrastructure;
+using cv19ResSupportV3.V4.Factories;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
@@ -29,6 +30,9 @@ namespace cv19ResSupportV3.Tests.V3.E2ETests
         public async Task GetResidentInformationByIdReturnsTheCorrectInformation()
         {
             var requestObject = new Fixture().Create<HelpRequestCreateRequestBoundary>();
+            requestObject.CaseNotes = "";
+            Console.WriteLine("requestObject");
+            Console.WriteLine(requestObject);
             var data = JsonConvert.SerializeObject(requestObject);
             HttpContent postContent = new StringContent(data, Encoding.UTF8, "application/json");
             var uri = new Uri($"api/v3/help-requests", UriKind.Relative);

--- a/cv19ResSupportV3.Tests/V3/Gateways/CaseNotesGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/CaseNotesGatewayTest.cs
@@ -52,7 +52,7 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             DatabaseContext.HelpRequestEntities.Add(helpRequest);
             DatabaseContext.SaveChanges();
 
-            var result = _classUnderTest.CreateCaseNote(helpRequest.Id, resident.Id, "New Case Note");
+            var result = _classUnderTest.CreateCaseNote( resident.Id, helpRequest.Id, "New Case Note");
 
             var createdEntity = DatabaseContext.CaseNoteEntities.Find(result.Id);
 

--- a/cv19ResSupportV3.Tests/V3/Gateways/CaseNotesGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/CaseNotesGatewayTest.cs
@@ -52,7 +52,7 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             DatabaseContext.HelpRequestEntities.Add(helpRequest);
             DatabaseContext.SaveChanges();
 
-            var result = _classUnderTest.CreateCaseNote( resident.Id, helpRequest.Id, "New Case Note");
+            var result = _classUnderTest.CreateCaseNote(resident.Id, helpRequest.Id, "New Case Note");
 
             var createdEntity = DatabaseContext.CaseNoteEntities.Find(result.Id);
 

--- a/cv19ResSupportV3.Tests/V3/UseCase/CreateCaseNoteUseCaseTests.cs
+++ b/cv19ResSupportV3.Tests/V3/UseCase/CreateCaseNoteUseCaseTests.cs
@@ -29,8 +29,8 @@ namespace cv19ResSupportV3.Tests.V3.UseCase
         {
             var expectedResponse = new ResidentCaseNote() { Id = 1, ResidentId = 1, HelpRequestId = 2, CaseNote = "data-to-save" };
             _mockGateway.Setup(s => s.CreateCaseNote(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>())).Returns(expectedResponse);
-            var response = _classUnderTest.Execute(expectedResponse.HelpRequestId, expectedResponse.ResidentId, expectedResponse.CaseNote);
-            _mockGateway.Verify(m => m.CreateCaseNote(expectedResponse.HelpRequestId, expectedResponse.ResidentId, expectedResponse.CaseNote), Times.Once());
+            var response = _classUnderTest.Execute(expectedResponse.ResidentId, expectedResponse.HelpRequestId, expectedResponse.CaseNote);
+            _mockGateway.Verify(m => m.CreateCaseNote(expectedResponse.ResidentId, expectedResponse.HelpRequestId, expectedResponse.CaseNote), Times.Once());
             response.Should().BeEquivalentTo(expectedResponse);
         }
     }

--- a/cv19ResSupportV3.Tests/V3/UseCase/CreateResidentAndHelpRequestUseCaseTest.cs
+++ b/cv19ResSupportV3.Tests/V3/UseCase/CreateResidentAndHelpRequestUseCaseTest.cs
@@ -30,7 +30,7 @@ namespace cv19ResSupportV3.Tests.V3.UseCase
         [Test]
         public void CreatesANewResidentIfItDoesntExistAndSavesANewHelpRequest()
         {
-            _fakeCreateResidentUseCase.Setup(s => s.Execute(It.IsAny<CreateResident>())).Returns(new Resident() { Id = 1 });
+            _fakeCreateResidentUseCase.Setup(s => s.Execute(It.IsAny<CreateResident>())).Returns(new Resident { Id = 1 });
             _fakeCreateHelpRequestUseCase.Setup(s => s.Execute(It.IsAny<int>(), It.IsAny<CreateHelpRequest>())).Returns(2);
             _fakeCreateCaseNoteUseCase.Setup(s => s.Execute(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>())).Verifiable();
 
@@ -40,7 +40,7 @@ namespace cv19ResSupportV3.Tests.V3.UseCase
             _fakeCreateResidentUseCase.Verify(m => m.Execute(It.IsAny<CreateResident>()), Times.Once());
             _fakeCreateHelpRequestUseCase.Verify(m => m.Execute(It.Is<int>(x => x == 1), It.IsAny<CreateHelpRequest>()), Times.Once());
 
-            _fakeCreateCaseNoteUseCase.Verify(m => m.Execute(2, 1, "saved"), Times.Once());
+            _fakeCreateCaseNoteUseCase.Verify(m => m.Execute(1, 2, "saved"), Times.Once());
             response.Should().Be(2);
         }
     }

--- a/cv19ResSupportV3.Tests/V4/Controllers/CaseNotesControllerTests.cs
+++ b/cv19ResSupportV3.Tests/V4/Controllers/CaseNotesControllerTests.cs
@@ -31,10 +31,13 @@ namespace cv19ResSupportV3.Tests.V4.Controllers
         [Test]
         public void CreateReturnsResponseWithStatus()
         {
+            var residentId = 100;
+            var helpRequestId = 2;
             var request = new CreateCaseNoteRequest() { CaseNote = "{\"author\": \"Name\", caseNote: \"note\" }" };
             _createCaseNoteUseCase.Setup(uc => uc.Execute(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()))
                 .Returns(new ResidentCaseNote() { Id = 1 });
-            var response = _classUnderTest.CreateCaseNote(1, 1, request) as CreatedResult;
+            var response = _classUnderTest.CreateCaseNote(residentId, helpRequestId, request) as CreatedResult;
+            _createCaseNoteUseCase.Verify(m => m.Execute(residentId, helpRequestId, It.IsAny<string>()), Times.Once);
             response.StatusCode.Should().Be(201);
         }
 

--- a/cv19ResSupportV3/V3/Gateways/CaseNotesGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/CaseNotesGateway.cs
@@ -47,7 +47,7 @@ namespace cv19ResSupportV3.V3.Gateways
             }
         }
 
-        public ResidentCaseNote CreateCaseNote(int residentId , int helpRequestId, string caseNote)
+        public ResidentCaseNote CreateCaseNote(int residentId, int helpRequestId, string caseNote)
         {
             try
             {

--- a/cv19ResSupportV3/V3/Gateways/CaseNotesGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/CaseNotesGateway.cs
@@ -47,7 +47,7 @@ namespace cv19ResSupportV3.V3.Gateways
             }
         }
 
-        public ResidentCaseNote CreateCaseNote(int helpRequestId, int residentId, string caseNote)
+        public ResidentCaseNote CreateCaseNote(int residentId , int helpRequestId, string caseNote)
         {
             try
             {

--- a/cv19ResSupportV3/V3/Gateways/ICaseNotesGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ICaseNotesGateway.cs
@@ -6,7 +6,7 @@ namespace cv19ResSupportV3.V3.Gateways
     public interface ICaseNotesGateway
     {
         ResidentCaseNote PatchCaseNote(int helpRequestId, int residentId, string caseNote);
-        ResidentCaseNote CreateCaseNote(int helpRequestId, int residentId, string caseNote);
+        ResidentCaseNote CreateCaseNote(int residentId, int helpRequestId, string caseNote);
         ResidentCaseNote UpdateCaseNote(int helpRequestId, int residentId, string caseNote);
         List<ResidentCaseNote> GetByResidentId(int residentId);
         List<ResidentCaseNote> GetByHelpRequestId(int helpRequestId);

--- a/cv19ResSupportV3/V3/UseCase/CreateCaseNoteUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/CreateCaseNoteUseCase.cs
@@ -13,7 +13,7 @@ namespace cv19ResSupportV3.V3.UseCase
         }
         public ResidentCaseNote Execute(int residentId, int helpRequestId, string caseNoteContent)
         {
-            var response = _gateway.CreateCaseNote( residentId, helpRequestId, caseNoteContent);
+            var response = _gateway.CreateCaseNote(residentId, helpRequestId, caseNoteContent);
             return response;
         }
     }

--- a/cv19ResSupportV3/V3/UseCase/CreateCaseNoteUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/CreateCaseNoteUseCase.cs
@@ -11,9 +11,9 @@ namespace cv19ResSupportV3.V3.UseCase
         {
             _gateway = gateway;
         }
-        public ResidentCaseNote Execute(int helpRequestId, int residentId, string caseNoteContent)
+        public ResidentCaseNote Execute(int residentId, int helpRequestId, string caseNoteContent)
         {
-            var response = _gateway.CreateCaseNote(helpRequestId, residentId, caseNoteContent);
+            var response = _gateway.CreateCaseNote( residentId, helpRequestId, caseNoteContent);
             return response;
         }
     }

--- a/cv19ResSupportV3/V3/UseCase/CreateResidentAndHelpRequestUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/CreateResidentAndHelpRequestUseCase.cs
@@ -24,7 +24,7 @@ namespace cv19ResSupportV3.V3.UseCase
             var helpRequestId = _createHelpRequestUseCase.Execute(resident.Id, command.ToCreateHelpRequestCommand());
             if (command.CaseNotes != null)
             {
-                _createCaseNote.Execute(resident.Id,helpRequestId, command.CaseNotes);
+                _createCaseNote.Execute(resident.Id, helpRequestId, command.CaseNotes);
             }
 
             return helpRequestId;

--- a/cv19ResSupportV3/V3/UseCase/CreateResidentAndHelpRequestUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/CreateResidentAndHelpRequestUseCase.cs
@@ -24,7 +24,7 @@ namespace cv19ResSupportV3.V3.UseCase
             var helpRequestId = _createHelpRequestUseCase.Execute(resident.Id, command.ToCreateHelpRequestCommand());
             if (command.CaseNotes != null)
             {
-                _createCaseNote.Execute(helpRequestId, resident.Id, command.CaseNotes);
+                _createCaseNote.Execute(resident.Id,helpRequestId, command.CaseNotes);
             }
 
             return helpRequestId;

--- a/cv19ResSupportV3/V3/UseCase/Interfaces/ICreateCaseNoteUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/Interfaces/ICreateCaseNoteUseCase.cs
@@ -4,6 +4,6 @@ namespace cv19ResSupportV3.V3.UseCase.Interfaces
 {
     public interface ICreateCaseNoteUseCase
     {
-        ResidentCaseNote Execute(int id, int residentId, string command);
+        ResidentCaseNote Execute(int residentId, int id, string command);
     }
 }

--- a/cv19ResSupportV3/V4/Controllers/CaseNotesController.cs
+++ b/cv19ResSupportV3/V4/Controllers/CaseNotesController.cs
@@ -41,7 +41,7 @@ namespace cv19ResSupportV3.V4.Controllers
         [Route("help-requests/{help-request-id}/case-notes")]
         public IActionResult CreateCaseNote([FromRoute(Name = "id")] int residentId, [FromRoute(Name = "help-request-id")] int helpRequestId, [FromBody] CreateCaseNoteRequest caseNote)
         {
-            var response = _addCaseNoteUseCase.Execute(residentId,helpRequestId, caseNote.CaseNote);
+            var response = _addCaseNoteUseCase.Execute(residentId, helpRequestId, caseNote.CaseNote);
             return Created(new Uri($"api/v4/residents/{residentId}/help-requests/{helpRequestId}/case-notes/{response}", UriKind.Relative), response);
         }
 

--- a/cv19ResSupportV3/V4/Controllers/CaseNotesController.cs
+++ b/cv19ResSupportV3/V4/Controllers/CaseNotesController.cs
@@ -41,7 +41,7 @@ namespace cv19ResSupportV3.V4.Controllers
         [Route("help-requests/{help-request-id}/case-notes")]
         public IActionResult CreateCaseNote([FromRoute(Name = "id")] int residentId, [FromRoute(Name = "help-request-id")] int helpRequestId, [FromBody] CreateCaseNoteRequest caseNote)
         {
-            var response = _addCaseNoteUseCase.Execute(residentId, helpRequestId, caseNote.CaseNote);
+            var response = _addCaseNoteUseCase.Execute(residentId,helpRequestId, caseNote.CaseNote);
             return Created(new Uri($"api/v4/residents/{residentId}/help-requests/{helpRequestId}/case-notes/{response}", UriKind.Relative), response);
         }
 


### PR DESCRIPTION
# What
- Update the create help request use case in the controller to accept the parameters in the correct order 

# Why
- Previously, the incorrect parameters were passed into the execute method of the CreateCaseNote use-case in the controller. ResidentId was passed in place of HelpRequestId and vice versa

# Screenshots
na

# Link to ticket
n/a

# Notes
The frontend will also need to be fixed as it was the only place this endpoint was being used. These two should be released in parallel.

