### PR TITLE
Find resident deduplication fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -128,3 +128,6 @@ dotnet_diagnostic.CA1303.severity = none
 dotnet_diagnostic.CA1001.severity = none
 #Can reassign collections
 dotnet_diagnostic.CA2227.severity = none
+
+# Default severity for analyzer diagnostics with category 'Globalization'
+dotnet_analyzer_diagnostic.category-Globalization.severity = none

--- a/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
@@ -29,6 +29,7 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
 
         // If NHS numbers match, then:
         // Resident id is returned as duplicate.
+
         [Test]
         public void FindResidentReturnsAMatchIdWhenThereIsAResidentWithMatchingNHSNumber()
         {
@@ -69,11 +70,12 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
         // If NHS number is empty or null or does not match &
         // If Uprn is present, then:
         // Resident is considered a duplicate, when First Name, Last Name & Uprn match.
+
         [TestCase(null)]
         [TestCase("")]
         [TestCase(" ")]
         [TestCase("nhs number")]
-        public void FindResidentReturnsAMatchWhenNoNhsNumberIsPresentAndWhenThereIsAResidentWithMatchingNonEmptyUprnAndFirstAndLastNames(string testCaseNhsNumber)
+        public void FindResidentReturnsAMatchWhenNoNhsNumberIsPresentAndWhenThereIsAResidentWithMatchingNonEmptyUprnAndFirstAndLastNamesForAllEmptyCasesOfNhsNumber(string testCaseNhsNumber)
         {
             // arrange
             var matchingEmptyNhsNumber = testCaseNhsNumber;
@@ -128,17 +130,19 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
         // If Uprn is empty or null or does not match &
         // If any of the Dob fields are missing (The focus here is on the Uprn paths, not the dob), then:
         // Resident is considered unique even when the First Name, Last Name & Nonempty Uprn match.
+
         [TestCase(null)]
         [TestCase("")]
         [TestCase(" ")]
         [TestCase("uprn")]
-        public void FindResidentReturnsNoMatchWhenNoNhsNumberAndUprnNumberAndAnyOfTheDobFieldsArePresent(string testCaseUprn)
+        public void FindResidentReturnsNoMatchWhenNoNhsNumberAndUprnNumberAndAnyOfTheDobFieldsArePresentForAllEmptyCasesOfUprn(string testCaseUprn)
         {
             // arrange
             var notMatchingNhsNumber = _faker.Random.Hash();
             var matchingFirstName = _faker.Random.Hash();
             var matchingLastName = _faker.Random.Hash();
             var matchingEmptyUprn = testCaseUprn;
+            // not even setting Dob fields (null by default)
 
             var searchParameters = new FindResident
             {
@@ -165,7 +169,7 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             };
 
             // testing a case path, where uprn is not empty, but still does not match
-            if (matchingEmptyUprn == "uprn") existingResidentEmptyUprnMatch.NhsNumber = _faker.Random.Hash();
+            if (matchingEmptyUprn == "uprn") existingResidentEmptyUprnMatch.Uprn = _faker.Random.Hash();
 
             DatabaseContext.ResidentEntities.Add(existingResidentNoUprnMatch);
             DatabaseContext.ResidentEntities.Add(existingResidentEmptyUprnMatch);
@@ -185,11 +189,12 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
         // If Dob is non-empty and not null, then
         // Resident is considered a duplicate when its Dob, Fname & Lname match.
         // (Difference between this test and the above one is that for the same given UPRNs, DOBs are no longer empty)
+
         [TestCase(null)]
         [TestCase("")]
         [TestCase(" ")]
         [TestCase("uprn")]
-        public void FindResidentReturnsAMatchWhenNoNhsAndUprnNumberMatchIsFoundButThereExistsAResidentWithMatchingFirstAndLastNameAndDOB(string testCaseUprn)
+        public void FindResidentReturnsAMatchWhenNoNhsAndUprnNumberMatchIsFoundButThereExistsAResidentWithMatchingFirstAndLastNameAndDOBForAllEmptyCasesOfUprn(string testCaseUprn)
         {
             // arrange
             var notMatchingNhsNumber = _faker.Random.Hash();
@@ -265,11 +270,12 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
         // that if the following 3 combinations pass, then the code works for all 27 (unless we're dealing with many lines of code of IF statments).
         // (Difference from one of the tests above is that this test assumes the UPRN rule is tested for all UPRN inputs, and it's only looking at
         // the possible DOB inputs under the case of assumed bad UPRN input)
+
         [TestCase(null, null, null)]
         [TestCase("", "", "")]
         [TestCase(" ", " ", " ")]
         [TestCase("23", "1", "1994")]
-        public void FindResidentReturnsNoMatchWhenNoNhsAndUprnNumberMatchIsFoundAndThereIsNoResidentWithMatchingFirstAndLastNameAndDOB(string tcDay, string tcMonth, string tcYear)
+        public void FindResidentReturnsNoMatchWhenNoNhsAndUprnNumberMatchIsFoundAndThereIsNoResidentWithMatchingDOBForParticularCasesOfDobFieldsBeingEmpty(string tcDay, string tcMonth, string tcYear)
         {
             // arrange
             var notMatchingNhsNumber = _faker.Random.Hash();
@@ -306,7 +312,7 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             var existingResidentEmptyDOBMatch = new ResidentEntity
             {
                 NhsNumber = _faker.Random.Hash(),
-                Uprn = notMatchingUprn,
+                Uprn = _faker.Random.Hash(),
                 FirstName = matchingFirstName,
                 LastName = matchingLastName,
                 DobDay = emptyMatchingDOBDay,
@@ -333,16 +339,19 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             // assert
             isResidentDuplicate.Should().BeFalse();
             duplicateResidentId.Should().Be(null);
-
         }
 
         // Should there be checks for the inserted records values?
         // Also should this case be treated as Unique Resident or the 400 Bad Request? (There doesn't seem to be validation preventing this)
         // For now will treat this as a new unique record.
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase(" ")]
-        public void FindResidentReturnsNoMatchWhenEitherFirstNameAndLastNameIsMissing(bool isDobTest, string testCaseName)
+
+        [TestCase(false, null)] //should throw
+        [TestCase(false, "")]
+        [TestCase(false, " ")]
+        [TestCase(true, null)]
+        [TestCase(true, "")]
+        [TestCase(true, " ")]
+        public void FindResidentReturnsNoMatchWhenEitherFirstNameOrLastNameIsMissingForAllEmptyCases(bool isDobTest, string testCaseName)
         {
             // arrange
             var notMatchingNhsNumber = _faker.Random.Hash();

--- a/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
@@ -56,15 +56,13 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             DatabaseContext.ResidentEntities.Add(existingResidentNhsNumberMatch);
             DatabaseContext.SaveChanges();
 
-            var nhsNumberMatchResidentId = DatabaseContext.ResidentEntities.FirstOrDefault(r => r.NhsNumber == matchingNhsNumber)?.Id;
-
             // act
             var duplicateResidentId = _classUnderTest.FindResident(searchParameters);
             bool isResidentDuplicate = duplicateResidentId != null;
 
             // assert
             isResidentDuplicate.Should().BeTrue();
-            duplicateResidentId.Should().Be(nhsNumberMatchResidentId);
+            duplicateResidentId.Should().Be(existingResidentNhsNumberMatch.Id);
         }
 
         // If NHS number is empty or null or does not match &
@@ -115,15 +113,13 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             DatabaseContext.ResidentEntities.Add(existingResidentUprnMatch);
             DatabaseContext.SaveChanges();
 
-            var uprnMatchResidentId = DatabaseContext.ResidentEntities.FirstOrDefault(r => r.Uprn == matchingUprn)?.Id;
-
             // act
             var duplicateResidentId = _classUnderTest.FindResident(searchParameters);
             bool isResidentDuplicate = duplicateResidentId != null;
 
             // assert
             isResidentDuplicate.Should().BeTrue();
-            duplicateResidentId.Should().Be(uprnMatchResidentId);
+            duplicateResidentId.Should().Be(existingResidentUprnMatch.Id);
         }
 
         // If NHS number is empty or null or does not match &
@@ -246,20 +242,13 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             DatabaseContext.ResidentEntities.Add(existingResidentDOBMatch);
             DatabaseContext.SaveChanges();
 
-            var dobMatchResidentId = DatabaseContext.ResidentEntities
-                .FirstOrDefault(r =>
-                    r.DobDay == matchingDOBDay &&
-                    r.DobMonth == matchingDOBMonth &&
-                    r.DobYear == matchingDOBYear
-                )?.Id;
-
             // act
             var duplicateResidentId = _classUnderTest.FindResident(searchParameters);
             bool isResidentDuplicate = duplicateResidentId != null;
 
             // assert
             isResidentDuplicate.Should().BeTrue();
-            duplicateResidentId.Should().Be(dobMatchResidentId);
+            duplicateResidentId.Should().Be(existingResidentDOBMatch.Id);
         }
 
         // If NHS number rule returns no match &
@@ -453,12 +442,6 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             DatabaseContext.ResidentEntities.Add(existingResidentWithNonTrimmedNhsNumber);
             DatabaseContext.SaveChanges();
 
-            var ResidentWithNormalNhsNumberId1 = DatabaseContext.ResidentEntities
-                .FirstOrDefault(r => r.NhsNumber == nhsNumber1)?.Id;
-
-            var ResidentWithNormalNhsNumberId2 = DatabaseContext.ResidentEntities
-                .FirstOrDefault(r => r.NhsNumber == nonTrimmedNHSNumber2)?.Id;
-
             // act
             var duplicateResidentId1 = _classUnderTest.FindResident(searchParameters1); // trimmed in DB
             bool isResidentDuplicate1 = duplicateResidentId1 != null;
@@ -468,10 +451,10 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
 
             // assert
             isResidentDuplicate1.Should().BeTrue(); // trimmed in DB
-            duplicateResidentId1.Should().Be(ResidentWithNormalNhsNumberId1);
+            duplicateResidentId1.Should().Be(existingResidentWithNormalNhsNumber.Id);
 
             isResidentDuplicate2.Should().BeTrue(); // trimmed in request
-            duplicateResidentId2.Should().Be(ResidentWithNormalNhsNumberId2);
+            duplicateResidentId2.Should().Be(existingResidentWithNonTrimmedNhsNumber.Id);
         }
 
         #endregion

--- a/cv19ResSupportV3.Tests/V4/E2ETests/SearchResidents.cs
+++ b/cv19ResSupportV3.Tests/V4/E2ETests/SearchResidents.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using AutoFixture;
 using Bogus;
 using cv19ResSupportV3.Tests.V3.E2ETests;
-using cv19ResSupportV3.Tests.V4.Helpers;
+using cv19ResSupportV3.Tests.V4.TestHelpers;
 using cv19ResSupportV3.V3.Factories;
 using cv19ResSupportV3.V3.Infrastructure;
 using cv19ResSupportV3.V4;

--- a/cv19ResSupportV3.Tests/V4/Helpers/PredicatesTests.cs
+++ b/cv19ResSupportV3.Tests/V4/Helpers/PredicatesTests.cs
@@ -1,0 +1,42 @@
+using System;
+using Bogus;
+using cv19ResSupportV3.V4.Helpers;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.TestHelpers
+{
+    [TestFixture]
+    public class PredicatesTests
+    {
+        Faker _faker = new Faker();
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void IsNotNullAndNotEmptyPredicateReturnsFalseWhenAStringIsEmpty(string testCaseString)
+        {
+            // arrange
+            var testString = testCaseString;
+
+            // act
+            var evaluationResult = Predicates.IsNotNullAndNotEmpty(testString);
+
+            // assert
+            evaluationResult.Should().BeFalse();
+        }
+
+        [Test]
+        public void IsNotNullAndNotEmptyPredicateReturnsTrueWhenAStringIsNonEmpty()
+        {
+            // arrange
+            var testString = _faker.Random.Hash();
+
+            // act
+            var evaluationResult = Predicates.IsNotNullAndNotEmpty(testString);
+
+            // assert
+            evaluationResult.Should().BeTrue();
+        }
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/TestHelpers/EntityHelpers.cs
+++ b/cv19ResSupportV3.Tests/V4/TestHelpers/EntityHelpers.cs
@@ -4,7 +4,7 @@ using cv19ResSupportV3.V3.Infrastructure;
 using LBHFSSPublicAPI.Tests.TestHelpers;
 using AutoFixture;
 
-namespace cv19ResSupportV3.Tests.V4.Helpers
+namespace cv19ResSupportV3.Tests.V4.TestHelpers
 {
     public static class EntityHelpers
     {

--- a/cv19ResSupportV3.Tests/cv19ResSupportV3.Tests.csproj
+++ b/cv19ResSupportV3.Tests/cv19ResSupportV3.Tests.csproj
@@ -35,4 +35,7 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="V4\TestHelpers\" />
+  </ItemGroup>
 </Project>

--- a/cv19ResSupportV3/V3/Domain/Commands/FindResident.cs
+++ b/cv19ResSupportV3/V3/Domain/Commands/FindResident.cs
@@ -2,6 +2,7 @@ namespace cv19ResSupportV3.V3.Domain.Commands
 {
     public class FindResident
     {
+        public string NhsNumber { get; set; } //Not mapped yet! Added for the sake of tests so far.
         public string Uprn { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }

--- a/cv19ResSupportV3/V3/Factories/Commands/FindResidentFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/Commands/FindResidentFactory.cs
@@ -14,7 +14,8 @@ namespace cv19ResSupportV3.V3.Factories.Commands
                 DobMonth = command.DobMonth,
                 DobYear = command.DobYear,
                 DobDay = command.DobDay,
-                Postcode = command.Postcode
+                Postcode = command.Postcode,
+                NhsNumber = command.NhsNumber
             };
         }
     }

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -172,7 +172,7 @@ namespace cv19ResSupportV3.V3.Gateways
                 if (Predicates.IsNotNullAndNotEmpty(command.NhsNumber))
                 {
                     var matchingResident = _helpRequestsContext.ResidentEntities
-                        .FirstOrDefault(r => r.NhsNumber.ToUpper() == command.NhsNumber.ToUpper());
+                        .FirstOrDefault(r => r.NhsNumber.Trim().ToUpper() == command.NhsNumber.Trim().ToUpper());
 
                     if (matchingResident != null)
                         return matchingResident.Id;

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -182,7 +182,12 @@ namespace cv19ResSupportV3.V3.Gateways
                         return matchingResident.Id;
                 }
 
-                if (command.DobDay != null || command.DobMonth != null || command.DobYear != null)
+                // Will ignore cases, where for instance DobYear and DobMonth are not empty, but DobDay is empty
+                // which I believe is a sensible result, as we can't guarantee that's the same person: there are
+                // 28 to 31 combinations of the Dob, when only those 2 fields are given.
+                if (Predicates.IsNotNullAndNotEmpty(command.DobYear) &&
+                    Predicates.IsNotNullAndNotEmpty(command.DobMonth) &&
+                    Predicates.IsNotNullAndNotEmpty(command.DobDay))
                 {
                     var matchingResident = _helpRequestsContext.ResidentEntities
                         .FirstOrDefault(r =>

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -7,6 +7,7 @@ using cv19ResSupportV3.V3.Domain;
 using cv19ResSupportV3.V3.Domain.Commands;
 using cv19ResSupportV3.V3.Factories;
 using cv19ResSupportV3.V3.Infrastructure;
+using cv19ResSupportV3.V4.Helpers;
 using Microsoft.EntityFrameworkCore;
 
 namespace cv19ResSupportV3.V3.Gateways
@@ -164,38 +165,36 @@ namespace cv19ResSupportV3.V3.Gateways
             return _helpRequestsContext.ResidentEntities.Find(id).ToDomain();
         }
 
-
         public int? FindResident(FindResident command)
         {
             try
             {
                 if (command.Uprn != null)
                 {
-                    var response = _helpRequestsContext.ResidentEntities.FirstOrDefault(x =>
-                        x.Uprn.ToUpper().Trim() == command.Uprn.ToUpper().Trim() &&
-                        x.FirstName.ToUpper().Trim() ==
-                        command.FirstName.ToUpper().Trim() &&
-                        x.LastName.ToUpper()
-                            .Trim() ==
-                        command.LastName.ToUpper().Trim());
-                    if (response != null)
-                    {
-                        return response.Id;
-                    }
+                    var matchingResident = _helpRequestsContext.ResidentEntities
+                        .FirstOrDefault(r =>
+                            //uprn is all numbers, no need to change case
+                            r.Uprn.Trim() == command.Uprn.Trim() &&
+                            r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
+                            r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+
+                    if (matchingResident != null)
+                        return matchingResident.Id;
                 }
 
                 if (command.DobDay != null || command.DobMonth != null || command.DobYear != null)
                 {
-                    var response = _helpRequestsContext.ResidentEntities.FirstOrDefault(x =>
-                        x.DobDay.Trim() == command.DobDay.Trim() &&
-                        x.DobMonth.Trim() == command.DobMonth.Trim() &&
-                        x.DobYear.Trim() == command.DobYear.Trim() &&
-                        x.FirstName.ToUpper().Trim() == command.FirstName.ToUpper().Trim() &&
-                        x.LastName.ToUpper().Trim() == command.LastName.ToUpper().Trim());
-                    if (response != null)
-                    {
-                        return response.Id;
-                    }
+                    var matchingResident = _helpRequestsContext.ResidentEntities
+                        .FirstOrDefault(r =>
+                            r.DobYear.Trim() == command.DobYear.Trim() &&
+                            // adding .ToUpper here in case month is specified with alphabetic characters for some cases (Jan, Dec)
+                            r.DobMonth.Trim().ToUpper() == command.DobMonth.Trim().ToUpper() &&
+                            r.DobDay.Trim() == command.DobDay.Trim() &&
+                            r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
+                            r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+
+                    if (matchingResident != null)
+                        return matchingResident.Id;
                 }
 
                 return null;

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -169,6 +169,15 @@ namespace cv19ResSupportV3.V3.Gateways
         {
             try
             {
+                if (Predicates.IsNotNullAndNotEmpty(command.NhsNumber))
+                {
+                    var matchingResident = _helpRequestsContext.ResidentEntities
+                        .FirstOrDefault(r => r.NhsNumber.ToUpper() == command.NhsNumber.ToUpper());
+
+                    if (matchingResident != null)
+                        return matchingResident.Id;
+                }
+
                 // If Fname or Lname are missing, no point checking Uprn or Dob. When these two fields
                 // are missing, there's no way to confirm whether it's the same person or not (unless nhs numbers match).
                 if (Predicates.IsNotNullAndNotEmpty(command.FirstName) &&

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -169,37 +169,43 @@ namespace cv19ResSupportV3.V3.Gateways
         {
             try
             {
-                if (Predicates.IsNotNullAndNotEmpty(command.Uprn))
+                // If Fname or Lname are missing, no point checking Uprn or Dob. When these two fields
+                // are missing, there's no way to confirm whether it's the same person or not (unless nhs numbers match).
+                if (Predicates.IsNotNullAndNotEmpty(command.FirstName) &&
+                    Predicates.IsNotNullAndNotEmpty(command.LastName))
                 {
-                    var matchingResident = _helpRequestsContext.ResidentEntities
-                        .FirstOrDefault(r =>
-                            //uprn is all numbers, no need to change case
-                            r.Uprn.Trim() == command.Uprn.Trim() &&
-                            r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
-                            r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+                    if (Predicates.IsNotNullAndNotEmpty(command.Uprn))
+                    {
+                        var matchingResident = _helpRequestsContext.ResidentEntities
+                            .FirstOrDefault(r =>
+                                //uprn is all numbers, no need to change case
+                                r.Uprn.Trim() == command.Uprn.Trim() &&
+                                r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
+                                r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
 
-                    if (matchingResident != null)
-                        return matchingResident.Id;
-                }
+                        if (matchingResident != null)
+                            return matchingResident.Id;
+                    }
 
-                // Will ignore cases, where for instance DobYear and DobMonth are not empty, but DobDay is empty
-                // which I believe is a sensible result, as we can't guarantee that's the same person: there are
-                // 28 to 31 combinations of the Dob, when only those 2 fields are given.
-                if (Predicates.IsNotNullAndNotEmpty(command.DobYear) &&
-                    Predicates.IsNotNullAndNotEmpty(command.DobMonth) &&
-                    Predicates.IsNotNullAndNotEmpty(command.DobDay))
-                {
-                    var matchingResident = _helpRequestsContext.ResidentEntities
-                        .FirstOrDefault(r =>
-                            r.DobYear.Trim() == command.DobYear.Trim() &&
-                            // adding .ToUpper here in case month is specified with alphabetic characters for some cases (Jan, Dec)
-                            r.DobMonth.Trim().ToUpper() == command.DobMonth.Trim().ToUpper() &&
-                            r.DobDay.Trim() == command.DobDay.Trim() &&
-                            r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
-                            r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+                    // Will ignore cases, where for instance DobYear and DobMonth are not empty, but DobDay is empty
+                    // which I believe is a sensible result, as we can't guarantee that's the same person: there are
+                    // 28 to 31 combinations of the Dob, when only those 2 fields are given.
+                    if (Predicates.IsNotNullAndNotEmpty(command.DobYear) &&
+                        Predicates.IsNotNullAndNotEmpty(command.DobMonth) &&
+                        Predicates.IsNotNullAndNotEmpty(command.DobDay))
+                    {
+                        var matchingResident = _helpRequestsContext.ResidentEntities
+                            .FirstOrDefault(r =>
+                                r.DobYear.Trim() == command.DobYear.Trim() &&
+                                // adding .ToUpper here in case month is specified with alphabetic characters for some cases (Jan, Dec)
+                                r.DobMonth.Trim().ToUpper() == command.DobMonth.Trim().ToUpper() &&
+                                r.DobDay.Trim() == command.DobDay.Trim() &&
+                                r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
+                                r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
 
-                    if (matchingResident != null)
-                        return matchingResident.Id;
+                        if (matchingResident != null)
+                            return matchingResident.Id;
+                    }
                 }
 
                 return null;

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -172,7 +172,7 @@ namespace cv19ResSupportV3.V3.Gateways
                 if (Predicates.IsNotNullAndNotEmpty(command.NhsNumber))
                 {
                     var matchingResident = _helpRequestsContext.ResidentEntities
-                        .FirstOrDefault(r => r.NhsNumber.Trim().ToUpper() == command.NhsNumber.Trim().ToUpper());
+                        .FirstOrDefault(r => r.NhsNumber.Trim() == command.NhsNumber.Trim());
 
                     if (matchingResident != null)
                         return matchingResident.Id;

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -169,7 +169,7 @@ namespace cv19ResSupportV3.V3.Gateways
         {
             try
             {
-                if (command.Uprn != null)
+                if (Predicates.IsNotNullAndNotEmpty(command.Uprn))
                 {
                     var matchingResident = _helpRequestsContext.ResidentEntities
                         .FirstOrDefault(r =>

--- a/cv19ResSupportV3/V4/Helpers/PredicateHelpers.cs
+++ b/cv19ResSupportV3/V4/Helpers/PredicateHelpers.cs
@@ -1,0 +1,10 @@
+namespace cv19ResSupportV3.V4.Helpers
+{
+    public static class Predicates
+    {
+        public static bool IsNotNullAndNotEmpty(string testString)
+        {
+            return testString != null && testString.Trim() != "";
+        }
+    }
+}

--- a/cv19ResSupportV3/cv19ResSupportV3.csproj
+++ b/cv19ResSupportV3/cv19ResSupportV3.csproj
@@ -24,4 +24,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.6.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="V4\Helpers\" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
# What
 - When first name, last name or both are missing the code won't proceed to Uprn & Dob matching rules.
 - All 3 of the Date of birth parts (Year, Month, Day) are required for the Dob rule to flag resident as duplicate. (Previously it was 1+)
 - More extensive check for empty values. Previously it was just a "null" check, now it also checks for empty and whitespace string as well.
 - Added NHS number rule for flagging resident as duplicate.
 - Minor code tweaks to make it more efficient & readable.

# Why
 - Deduplication isn't working as expected. It's flagging some residents as duplicate, when they are not. And it's not flagging some as duplicate when they are.

# Screenshots
 - No screenshot

# Link to ticket
 - Trello card: [107](https://trello.com/c/wkcGQa7x/107-bug-de-duping-on-api-too-aggressive).

# Notes
 - Suppressed the Globalisation suggestion as we're not building an international application that would expect multi-cultural strings. Did this to remove that obnoxious green squiggly line that made code harder to read. Judging from how long these warnings stayed around, I assume everyone's of the same opinion that adding those "Ignore Culture" options to every string method like .ToUpper() would make the code unpleasant and harder to read due to all the extra distraction from the key detail.
 - Require both first and last names to be non-empty, like mentioned in the commit. Having last name & uprn, or first name & dob is quite clearly not enough information to guarantee that the resident in question is a duplicate.
 - Added more extensive empty checks because, similarly as above, we can't guarantee that a person with a given first name, last name and empty uprn is a duplicate (even when empty uprns math: " " == " ").
 - All 3 parts of the date required as, like above, having a first name, last name and DobDay is not enough to guarantee resident is a duplicate. Same with other variations of Dob fields - at best (if DobYear & DobDay are provided) you can expect 12 combinations of dates containing the provided information, which is not great.
 - Any resident can have 1+ of NHS numbers, however no resident can have the NHS number that other has. Hence finding NHS number match is enough to guarantee resident is a duplicate. (Read more in commit message)

