### PR TITLE
Increase find resident accuracy

### DIFF
--- a/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
@@ -457,8 +457,173 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             duplicateResidentId2.Should().Be(existingResidentWithNonTrimmedNhsNumber.Id);
         }
 
-        #endregion
 
+        // When de-duplicating by dob, dobDay and dobMonth leading zeros are ignored
+        [Test]
+        public void WhenDeduplicatingByDobRuleFindResidentDoesNotLooseTrailingZerosByTrimmingLeadingZeros()
+        {
+            // arrange
+            // generic setup, so the rest would work
+            var matchingFirstName = _faker.Random.Hash();
+            var matchingLastName = _faker.Random.Hash();
+            var dobYear = _faker.Random.Hash();
+
+            // need to make sure we don't lose the non-leading zero's upon removing leading ones
+            var dobDay1 = "1";
+            var dobMonth1 = "1";
+
+            var dobDay10 = "10";
+            var dobMonth10 = "10";
+
+            // request date = 10, db date = 1
+            var searchParametersDate10 = new FindResident
+            {
+                FirstName = matchingFirstName,
+                LastName = matchingLastName,
+                DobDay = dobDay10,
+                DobMonth = dobMonth10,
+                DobYear = dobYear,
+            };
+
+            // Should not match. If it matches, it meanst the zero from "10" gets trimmed from request field
+            var existingResidentDate1InDB = new ResidentEntity
+            {
+                FirstName = matchingFirstName,
+                LastName = matchingLastName,
+                DobDay = dobDay1,
+                DobMonth = dobMonth1,
+                DobYear = dobYear
+            };
+
+            DatabaseContext.ResidentEntities.Add(existingResidentDate1InDB);
+
+            var dobDay2 = "2";
+            var dobMonth2 = "2";
+
+            var dobDay20 = "20";
+            var dobMonth20 = "20";
+
+            // request date = 2, db date = 20
+            var searchParametersDate2 = new FindResident
+            {
+                FirstName = matchingFirstName,
+                LastName = matchingLastName,
+                DobDay = dobDay2,
+                DobMonth = dobMonth2,
+                DobYear = dobYear,
+            };
+
+            // Should not match. If it matches, it meanst the zero from "20" gets trimmed from DB field
+            var existingResidentDate20InDB = new ResidentEntity
+            {
+                FirstName = matchingFirstName,
+                LastName = matchingLastName,
+                DobDay = dobDay20,
+                DobMonth = dobMonth20,
+                DobYear = dobYear
+            };
+
+            DatabaseContext.ResidentEntities.Add(existingResidentDate20InDB);
+
+            // act
+            var duplicateResidentDate1Id = _classUnderTest.FindResident(searchParametersDate10);
+            bool isResidentDate1Duplicate = duplicateResidentDate1Id != null;
+
+            var duplicateResidentDate20Id = _classUnderTest.FindResident(searchParametersDate2);
+            bool isResidentDate20Duplicate = duplicateResidentDate20Id != null;
+
+            // assert
+            isResidentDate1Duplicate.Should().BeFalse();
+            duplicateResidentDate1Id.Should().Be(null);
+
+            isResidentDate20Duplicate.Should().BeFalse();
+            duplicateResidentDate20Id.Should().Be(null);
+        }
+
+
+        [Test]
+        public void WhenDeduplicatingByDobRuleFindResidentReturnsAMatchEvenWhenDobDayAndMonthFieldsContainLeadingZeros()
+        {
+            // arrange
+            // generic setup, so the rest would work
+            var matchingFirstName = _faker.Random.Hash();
+            var matchingLastName = _faker.Random.Hash();
+            var dobYear = _faker.Random.Hash();
+
+            // other case - leading 0s in db, not in request
+            var requestDobDayAny = _faker.Random.Int(1, 4).ToString();
+            var requestDobMonthAny = _faker.Random.Int(1, 4).ToString();
+            var databaseDobDayAnyLeadingZero = "0" + requestDobDayAny;
+            var databaseDobMonthAnyLeadingZero = "0" + requestDobMonthAny;
+
+            // no leading zeros
+            var searchParametersNoLeadingZeros = new FindResident
+            {
+                FirstName = matchingFirstName,
+                LastName = matchingLastName,
+                DobDay = requestDobDayAny,
+                DobMonth = requestDobMonthAny,
+                DobYear = dobYear,
+            };
+
+            // with leading zeros
+            var existingResidentLeadingZeros = new ResidentEntity
+            {
+                FirstName = matchingFirstName,
+                LastName = matchingLastName,
+                DobDay = databaseDobDayAnyLeadingZero,
+                DobMonth = databaseDobMonthAnyLeadingZero,
+                DobYear = dobYear
+            };
+
+            DatabaseContext.ResidentEntities.Add(existingResidentLeadingZeros);
+
+            // other case - leading 0s in request, not in db
+            var databaseDobDayAny = _faker.Random.Int(5, 9).ToString();
+            var databaseDobMonthAny = _faker.Random.Int(5, 9).ToString();
+            var requestDobDayAnyLeadingZero = "0" + databaseDobDayAny;
+            var requestDobMonthAnyLeadingZero = "0" + databaseDobMonthAny;
+
+            // leading zeros
+            var searchParametersWithLeadingZeros = new FindResident
+            {
+                FirstName = matchingFirstName,
+                LastName = matchingLastName,
+                DobDay = requestDobDayAnyLeadingZero,
+                DobMonth = requestDobMonthAnyLeadingZero,
+                DobYear = dobYear,
+            };
+
+            // no leading zeros
+            var existingResidentNoneLeadingZeros = new ResidentEntity
+            {
+                FirstName = matchingFirstName,
+                LastName = matchingLastName,
+                DobDay = databaseDobDayAny,
+                DobMonth = databaseDobMonthAny,
+                DobYear = dobYear
+            };
+
+            DatabaseContext.ResidentEntities.Add(existingResidentNoneLeadingZeros);
+
+            DatabaseContext.SaveChanges();
+
+            // act
+            var duplicateResidentLeadZerosInDbId = _classUnderTest.FindResident(searchParametersNoLeadingZeros);
+            bool isResidentLeadZerosInDbDuplicate = duplicateResidentLeadZerosInDbId != null;
+
+            var duplicateResidentLeadZerosInRequestId = _classUnderTest.FindResident(searchParametersWithLeadingZeros);
+            bool isResidentLeadZerosInRequestDuplicate = duplicateResidentLeadZerosInRequestId != null;
+
+            // assert
+            isResidentLeadZerosInDbDuplicate.Should().BeTrue();
+            duplicateResidentLeadZerosInDbId.Should().Be(existingResidentLeadingZeros.Id);
+
+            isResidentLeadZerosInRequestDuplicate.Should().BeTrue();
+            duplicateResidentLeadZerosInRequestId.Should().Be(existingResidentNoneLeadingZeros.Id);
+        }
+
+        #endregion
 
         [Test]
         public void PatchResidentReturnsTheUpdatedResident()

--- a/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
@@ -460,7 +460,7 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
 
         // When de-duplicating by dob, dobDay and dobMonth leading zeros are ignored
         [Test]
-        public void WhenDeduplicatingByDobRuleFindResidentDoesNotLooseTrailingZerosByTrimmingLeadingZeros()
+        public void UponDeduplicatingByDobRuleFindResidentDoesNotLooseTrailingZerosByTrimmingLeadingZeros()
         {
             // arrange
             // generic setup, so the rest would work
@@ -524,6 +524,7 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             };
 
             DatabaseContext.ResidentEntities.Add(existingResidentDate20InDB);
+            DatabaseContext.SaveChanges();
 
             // act
             var duplicateResidentDate1Id = _classUnderTest.FindResident(searchParametersDate10);

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -172,7 +172,7 @@ namespace cv19ResSupportV3.V3.Gateways
                 if (Predicates.IsNotNullAndNotEmpty(command.NhsNumber))
                 {
                     var matchingResident = _helpRequestsContext.ResidentEntities
-                        .FirstOrDefault(r => r.NhsNumber.Trim() == command.NhsNumber.Trim());
+                        .FirstOrDefault(r => r.NhsNumber.Replace(" ", "") == command.NhsNumber.Replace(" ", ""));
 
                     if (matchingResident != null)
                         return matchingResident.Id;

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -207,8 +207,8 @@ namespace cv19ResSupportV3.V3.Gateways
                             .FirstOrDefault(r =>
                                 r.DobYear.Trim() == command.DobYear.Trim() &&
                                 // adding .ToUpper here in case month is specified with alphabetic characters for some cases (Jan, Dec)
-                                r.DobMonth.Trim().ToUpper() == command.DobMonth.Trim().ToUpper() &&
-                                r.DobDay.Trim() == command.DobDay.Trim() &&
+                                r.DobMonth.Trim().TrimStart('0').ToUpper() == command.DobMonth.Trim().TrimStart('0').ToUpper() &&
+                                r.DobDay.Trim().TrimStart('0') == command.DobDay.Trim().TrimStart('0') &&
                                 r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
                                 r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
 


### PR DESCRIPTION
# What
- Made NHS number match rule to ignore different NHS number formatting like: `485 777 3456` vs `4857773456`.
- Made Dob match rule ignore `DobMonth` and `DobDay` number formatting of leading zeros: `03` vs `3`.
- Added a missing test case from previous PR to cover code of matching `DobMonth` field of mixed cases (In case it's specified as word or abbreviation): `Jan`, `dec`, `april`, etc.

# Why
- To increase accuracy of resident de-duplication.

# Link to ticket
Trello: [ticket 135](https://trello.com/c/5q2Y8n3b/135-improve-de-duping-on-api-accuracy).

# Notes
Did this even though not priority, because I'm away for most of next week, and couldn't pick up anything other that would be small enough for the couple of hours I got today.

**This PR is related to bug** on [ticket 71](https://trello.com/c/g6clapaW/71-bug-call-request-and-contact-details-not-showing) **and** [PR on "Here to Help front-end"](https://github.com/LBHackney-IT/coronavirus-here-to-help-frontend/pull/60) corresponding to ticket 71.
The changes on this PR help to prevent some of such cases causing Trello 71 bug from the happening.

There's a test that limits random number from 1-4 in its 1st part, and 5-9 in other: `_faker.Random.Int(5, 9)`. That's done to avoid collision between random numbers of 2 test cases.
