### PR TITLE
Finding an existing help request now also matches by helpNeeded 

### DIFF
--- a/cv19ResSupportV3.Tests/V3/E2ETests/UpdateHelpRequest.cs
+++ b/cv19ResSupportV3.Tests/V3/E2ETests/UpdateHelpRequest.cs
@@ -77,6 +77,7 @@ namespace cv19ResSupportV3.Tests.V3.E2ETests
                 HelpWithNoNeedsIdentified = null,
                 HelpWithAccessingSupermarketFood = true,
                 Id = requestObject.Id,
+                HelpNeeded = requestObject.HelpNeeded,
             };
 
             var data = JsonConvert.SerializeObject(updateRequestObject);

--- a/cv19ResSupportV3.Tests/V3/E2ETests/UpdateHelpRequest.cs
+++ b/cv19ResSupportV3.Tests/V3/E2ETests/UpdateHelpRequest.cs
@@ -77,7 +77,6 @@ namespace cv19ResSupportV3.Tests.V3.E2ETests
                 HelpWithNoNeedsIdentified = null,
                 HelpWithAccessingSupermarketFood = true,
                 Id = requestObject.Id,
-                HelpNeeded = requestObject.HelpNeeded,
             };
 
             var data = JsonConvert.SerializeObject(updateRequestObject);

--- a/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
@@ -285,15 +285,15 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
         }
 
         [Test]
-        public void CanFindHelpRequestByCtasId()
+        public void CanFindHelpRequestByCtasIdAndHelpNeeded()
         {
             var resident = EntityHelpers.createResident(118);
-            var helpRequest = EntityHelpers.createHelpRequestEntity(117, resident.Id);
+            var helpRequest = EntityHelpers.createHelpRequestEntity(117, resident.Id, "Welfare Call");
             DatabaseContext.ResidentEntities.Add(resident);
             DatabaseContext.HelpRequestEntities.Add(helpRequest);
             DatabaseContext.SaveChanges();
 
-            var response = _classUnderTest.FindHelpRequestByCtasId(helpRequest.NhsCtasId);
+            var response = _classUnderTest.FindHelpRequestByCtasId(helpRequest.NhsCtasId, helpRequest.HelpNeeded);
 
             response.Should().Be(117);
         }
@@ -301,10 +301,25 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
         [Test]
         public void FindHelpRequestByCtasIdReturnsNullIfItDoesntExist()
         {
-            var response = _classUnderTest.FindHelpRequestByCtasId("anything");
+            var response = _classUnderTest.FindHelpRequestByCtasId("anything", "anything");
 
             response.Should().BeNull();
         }
+
+        [Test]
+        public void FindHelpRequestByCtasIdReturnsNullIfCtasIdExistsButHelpNeededDoesNotMatch()
+        {
+            var resident = EntityHelpers.createResident(118);
+            var helpRequest = EntityHelpers.createHelpRequestEntity(117, resident.Id, "Welfare Call");
+            DatabaseContext.ResidentEntities.Add(resident);
+            DatabaseContext.HelpRequestEntities.Add(helpRequest);
+            DatabaseContext.SaveChanges();
+
+            var response = _classUnderTest.FindHelpRequestByCtasId(helpRequest.NhsCtasId, "Shielding");
+
+            response.Should().BeNull();
+        }
+
         [Test]
         public void FindHelpRequestByMetadaReturnsNullIfItDoesntExist()
         {

--- a/cv19ResSupportV3.Tests/V3/Helpers/EntityHelpers.cs
+++ b/cv19ResSupportV3.Tests/V3/Helpers/EntityHelpers.cs
@@ -17,11 +17,12 @@ namespace cv19ResSupportV3.Tests.V3.Helpers
                 .Create();
             return helpRequestEntity;
         }
-        public static HelpRequestEntity createHelpRequestEntity(int id = 1, int residentId = 1)
+        public static HelpRequestEntity createHelpRequestEntity(int id = 1, int residentId = 1, string helpNeeded = "CallType")
         {
             var helpRequestEntity = Randomm.Build<HelpRequestEntity>()
                 .With(x => x.Id, id)
                 .With(x => x.ResidentId, residentId)
+                .With(x => x.HelpNeeded, helpNeeded)
                 .Without(h => h.HelpRequestCalls)
                 .Without(h => h.CaseNotes)
                 .Without(h => h.ResidentEntity)

--- a/cv19ResSupportV3.Tests/V3/UseCase/CreateHelpRequestUseCaseTests.cs
+++ b/cv19ResSupportV3.Tests/V3/UseCase/CreateHelpRequestUseCaseTests.cs
@@ -27,27 +27,28 @@ namespace cv19ResSupportV3.Tests.V3.UseCase
         [Test]
         public void SavesHelpRequestIfItDoesNotExist()
         {
-            _mockGateway.Setup(s => s.FindHelpRequestByCtasId(It.IsAny<string>())).Returns<int?>(null);
+            _mockGateway.Setup(s => s.FindHelpRequestByCtasId(It.IsAny<string>(), It.IsAny<string>())).Returns<int?>(null);
             _mockGateway.Setup(s => s.FindHelpRequestByMetadata(It.IsAny<string>(), It.IsAny<string>())).Returns<int?>(null);
             _mockGateway.Setup(s => s.CreateHelpRequest(It.IsAny<int>(), It.IsAny<CreateHelpRequest>())).Returns(1);
 
             var dataToSave = new Fixture().Build<CreateHelpRequest>().Create();
             var response = _classUnderTest.Execute(1, dataToSave);
-            _mockGateway.Verify(m => m.FindHelpRequestByCtasId(It.IsAny<string>()), Times.Once());
+            _mockGateway.Verify(m => m.FindHelpRequestByCtasId(It.IsAny<string>(), It.IsAny<string>()), Times.Once());
             _mockGateway.Verify(m => m.FindHelpRequestByMetadata("nsss_id", It.IsAny<object>()), Times.Once());
             _mockGateway.Verify(m => m.FindHelpRequestByMetadata("spl_id", It.IsAny<object>()), Times.Once());
             _mockGateway.Verify(m => m.CreateHelpRequest(It.IsAny<int>(), It.IsAny<CreateHelpRequest>()), Times.Once());
             response.Should().Be(1);
         }
+
         [Test]
-        public void DoesNotCreateNewHelpRequestIfItDoesExistWithCtasNumber()
+        public void DoesNotCreateNewHelpRequestIfItDoesExistWithCtasNumberAndCallType()
         {
-            _mockGateway.Setup(s => s.FindHelpRequestByCtasId(It.IsAny<string>())).Returns(1);
+            _mockGateway.Setup(s => s.FindHelpRequestByCtasId(It.IsAny<string>(), It.IsAny<string>())).Returns(1);
             _mockGateway.Setup(s => s.FindHelpRequestByMetadata(It.IsAny<string>(), It.IsAny<object>())).Returns<int?>(null);
 
             var dataToSave = new Fixture().Build<CreateHelpRequest>().Create();
             var response = _classUnderTest.Execute(1, dataToSave);
-            _mockGateway.Verify(m => m.FindHelpRequestByCtasId(It.IsAny<string>()), Times.Once());
+            _mockGateway.Verify(m => m.FindHelpRequestByCtasId(It.IsAny<string>(), It.IsAny<string>()), Times.Once());
             _mockGateway.Verify(m => m.FindHelpRequestByMetadata("nsss_id", It.IsAny<object>()), Times.Never());
             _mockGateway.Verify(m => m.FindHelpRequestByMetadata("spl_id", It.IsAny<object>()), Times.Never());
             _mockGateway.Verify(m => m.CreateHelpRequest(It.IsAny<int>(), It.IsAny<CreateHelpRequest>()), Times.Never);
@@ -57,12 +58,12 @@ namespace cv19ResSupportV3.Tests.V3.UseCase
         [Test]
         public void DoesNotCreateNewHelpRequestIfItExistWithNSSSMetadata()
         {
-            _mockGateway.Setup(s => s.FindHelpRequestByCtasId(It.IsAny<string>())).Returns<int?>(null);
+            _mockGateway.Setup(s => s.FindHelpRequestByCtasId(It.IsAny<string>(), It.IsAny<string>())).Returns<int?>(null);
             _mockGateway.Setup(s => s.FindHelpRequestByMetadata(It.IsAny<string>(), It.IsAny<object>())).Returns(1);
 
             var dataToSave = new Fixture().Build<CreateHelpRequest>().Create();
             var response = _classUnderTest.Execute(1, dataToSave);
-            _mockGateway.Verify(m => m.FindHelpRequestByCtasId(It.IsAny<string>()), Times.Once());
+            _mockGateway.Verify(m => m.FindHelpRequestByCtasId(It.IsAny<string>(), It.IsAny<string>()), Times.Once());
             _mockGateway.Verify(m => m.FindHelpRequestByMetadata("nsss_id", It.IsAny<object>()), Times.Once());
             _mockGateway.Verify(m => m.FindHelpRequestByMetadata("spl_id", It.IsAny<object>()), Times.Never());
             _mockGateway.Verify(m => m.CreateHelpRequest(It.IsAny<int>(), It.IsAny<CreateHelpRequest>()), Times.Never);
@@ -71,13 +72,13 @@ namespace cv19ResSupportV3.Tests.V3.UseCase
         [Test]
         public void DoesNotCreateNewHelpRequestIfItExistWithSPLMetadata()
         {
-            _mockGateway.Setup(s => s.FindHelpRequestByCtasId(It.IsAny<string>())).Returns<int?>(null);
+            _mockGateway.Setup(s => s.FindHelpRequestByCtasId(It.IsAny<string>(), It.IsAny<string>())).Returns<int?>(null);
             _mockGateway.Setup(s => s.FindHelpRequestByMetadata("nsss_id", It.IsAny<string>())).Returns<int?>(null);
             _mockGateway.Setup(s => s.FindHelpRequestByMetadata("spl_id", It.IsAny<object>())).Returns(1);
 
             var dataToSave = new Fixture().Build<CreateHelpRequest>().Create();
             var response = _classUnderTest.Execute(1, dataToSave);
-            _mockGateway.Verify(m => m.FindHelpRequestByCtasId(It.IsAny<string>()), Times.Once());
+            _mockGateway.Verify(m => m.FindHelpRequestByCtasId(It.IsAny<string>(), It.IsAny<string>()), Times.Once());
             _mockGateway.Verify(m => m.FindHelpRequestByMetadata("nsss_id", It.IsAny<object>()), Times.Once());
             _mockGateway.Verify(m => m.FindHelpRequestByMetadata("spl_id", It.IsAny<object>()), Times.Once());
             _mockGateway.Verify(m => m.CreateHelpRequest(It.IsAny<int>(), It.IsAny<CreateHelpRequest>()), Times.Never);

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -45,12 +45,12 @@ namespace cv19ResSupportV3.V3.Gateways
             }
         }
 
-        public int? FindHelpRequestByCtasId(string ctasId)
+        public int? FindHelpRequestByCtasId(string ctasId, string helpNeeded)
         {
             try
             {
                 if (ctasId == null) return null;
-                var helpRequestEntity = _helpRequestsContext.HelpRequestEntities.FirstOrDefault(x => x.NhsCtasId == ctasId);
+                var helpRequestEntity = _helpRequestsContext.HelpRequestEntities.FirstOrDefault(x => x.NhsCtasId == ctasId && x.HelpNeeded.ToUpper() == helpNeeded.ToUpper());
                 return helpRequestEntity?.Id;
             }
             catch (Exception e)

--- a/cv19ResSupportV3/V3/Gateways/IHelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/IHelpRequestGateway.cs
@@ -8,7 +8,7 @@ namespace cv19ResSupportV3.V3.Gateways
     public interface IHelpRequestGateway
     {
         int CreateHelpRequest(int residentId, CreateHelpRequest command);
-        int? FindHelpRequestByCtasId(string ctasId);
+        int? FindHelpRequestByCtasId(string ctasId, string helpNeeded);
         int? FindHelpRequestByMetadata(string propertyName, dynamic metadata);
         List<LookupDomain> GetLookups(LookupQuery command);
         HelpRequest UpdateHelpRequest(int id, UpdateHelpRequest command);

--- a/cv19ResSupportV3/V3/UseCase/CreateHelpRequestUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/CreateHelpRequestUseCase.cs
@@ -13,7 +13,7 @@ namespace cv19ResSupportV3.V3.UseCase
         }
         public int Execute(int residentId, CreateHelpRequest command)
         {
-            var helpRequestId = _gateway.FindHelpRequestByCtasId(command.NhsCtasId);
+            var helpRequestId = _gateway.FindHelpRequestByCtasId(command.NhsCtasId, command.HelpNeeded);
             if (helpRequestId != null) { return (int) helpRequestId; }
 
             helpRequestId = _gateway.FindHelpRequestByMetadata("nsss_id", command.Metadata);


### PR DESCRIPTION
# What
Finding an existing help request now also matches by helpNeeded as well as CTAS ID. This means multiple help requests can exist for a single CTAS ID as long as the help required differs.

# What
Added helpNeeded to the gateway call to check if a Help Request exists. Updated unit tests and added a new one for this condition.

# Why
We're adding a new ingest type to the HTH ingest that will be calling this API. Without this change, someone could potentially have a help request from another ingest that would prevent the new help request being saved in the system.

# Screenshots
N/A

# Ticket
'Here To Help' JIRA ticket HTHD-37


