### PR TITLE
Added more Resident de-duplication rules.

### DIFF
--- a/cv19ResSupportV3.Tests/V3/Factories/ResidentFactoryTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Factories/ResidentFactoryTest.cs
@@ -12,6 +12,8 @@ namespace cv19ResSupportV3.Tests.V3.Factories
     [TestFixture]
     public class ResidentFactoryTest
     {
+        private Fixture _fixture = new Fixture();
+
         [Test]
         public void CanMapResidentEntitiesResidentDomain()
         {
@@ -23,10 +25,31 @@ namespace cv19ResSupportV3.Tests.V3.Factories
         [Test]
         public void CanMapCreateResidentDomainToResidentEntity()
         {
-            var request = new CreateResident();
+            var request = _fixture.Create<CreateResident>();
             var command = request.ToResidentEntity();
-            command.Should().BeEquivalentTo(request);
+
             command.Should().BeOfType<ResidentEntity>();
+
+            command.Postcode.Should().Be(request.Postcode);
+            command.Uprn.Should().Be(request.Uprn);
+            command.Ward.Should().Be(request.Ward);
+            command.AddressFirstLine.Should().Be(request.AddressFirstLine);
+            command.AddressSecondLine.Should().Be(request.AddressSecondLine);
+            command.AddressThirdLine.Should().Be(request.AddressThirdLine);
+            command.IsPharmacistAbleToDeliver.Should().Be(request.IsPharmacistAbleToDeliver);
+            command.NameAddressPharmacist.Should().Be(request.NameAddressPharmacist);
+            command.FirstName.Should().Be(request.FirstName);
+            command.LastName.Should().Be(request.LastName);
+            command.DobMonth.Should().Be(request.DobMonth);
+            command.DobYear.Should().Be(request.DobYear);
+            command.DobDay.Should().Be(request.DobDay);
+            command.ContactTelephoneNumber.Should().Be(request.ContactTelephoneNumber);
+            command.ContactMobileNumber.Should().Be(request.ContactMobileNumber);
+            command.EmailAddress.Should().Be(request.EmailAddress);
+            command.GpSurgeryDetails.Should().Be(request.GpSurgeryDetails);
+            command.NumberOfChildrenUnder18.Should().Be(request.NumberOfChildrenUnder18);
+            command.ConsentToShare.Should().Be(request.ConsentToShare);
+            command.NhsNumber.Should().Be(request.NhsNumber);
         }
     }
 }

--- a/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
@@ -598,6 +598,10 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             duplicateResidentIdAttempt2.Should().Be(null);
         }
 
+        #endregion
+
+        #region Formatting-insensitive de-duplication tests
+
         [Test]
         public void FindResidentReturnsAMatchByNhsNumberEvenWhenProvidedNhsNumberIsNotTrimmed()
         {

--- a/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
@@ -338,6 +338,8 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             // create matching secondary fields
             var matchingNhsCtasId = _faker.Random.AlphaNumeric(8);
             var matchingEmailAddress = _faker.Person.Email;
+            var matchingContactMobileNumber = _faker.Random.Hash();
+            var matchingContactTelephoneNumber = _faker.Random.Hash();
 
             // create a request object
             var searchParameters = new FindResident
@@ -345,26 +347,31 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
                 FirstName = _faker.Random.Hash(),
                 LastName = _faker.Random.Hash(),
                 EmailAddress = matchingEmailAddress,
+                ContactMobileNumber = matchingContactMobileNumber,
+                ContactTelephoneNumber = matchingContactTelephoneNumber,
                 NhsCtasId = matchingNhsCtasId
             };
 
             // create a resident with a child help case containing matching NhsCtasId
-            var residentWithMachingCtasCase = EntityHelpers.createResident(id: _faker.Random.Int(10, 1000));
+            var residentWithMachingRemainingData = EntityHelpers.createResident(id: _faker.Random.Int(10, 1000));
+            residentWithMachingRemainingData.EmailAddress = matchingEmailAddress;
+            residentWithMachingRemainingData.ContactMobileNumber = matchingContactMobileNumber;
+            residentWithMachingRemainingData.ContactTelephoneNumber = matchingContactTelephoneNumber;
 
             var matchingNhsCtasIdHelpCase = EntityHelpers.createHelpRequestEntity(
                 id: _faker.Random.Int(100, 1000), // avoid potential inter-test clash
-                residentId: residentWithMachingCtasCase.Id);
+                residentId: residentWithMachingRemainingData.Id);
             matchingNhsCtasIdHelpCase.NhsCtasId = matchingNhsCtasId;
 
             // create non-matching by everything (control) resident
-            var controlResident = EntityHelpers.createResident(id: residentWithMachingCtasCase.Id + 1); // making sure ids are different
+            var controlResident = EntityHelpers.createResident(id: residentWithMachingRemainingData.Id + 1); // making sure ids are different
 
             var controlHelpCase = EntityHelpers.createHelpRequestEntity(
                 id: matchingNhsCtasIdHelpCase.Id + 1, // making sure ids are different
                 residentId: controlResident.Id);
 
             // add resident entities
-            DatabaseContext.ResidentEntities.Add(residentWithMachingCtasCase);
+            DatabaseContext.ResidentEntities.Add(residentWithMachingRemainingData);
             DatabaseContext.ResidentEntities.Add(controlResident);
 
             // add help request entities

--- a/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
@@ -401,18 +401,22 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             //// arrange
 
             // create matching Nhs Ctas Id
+            var matchingFirstName = _faker.Random.Hash();
+            var matchingLastName = _faker.Random.Hash();
             var ruleFailingNhsCtasId = testCaseNhsCtasId;
 
             // create a request object
             var searchParameters = new FindResident
             {
-                FirstName = _faker.Random.Hash(),
-                LastName = _faker.Random.Hash(),
+                FirstName = matchingFirstName,
+                LastName = matchingLastName,
                 NhsCtasId = ruleFailingNhsCtasId
             };
 
             // create a resident with a child help case containing matching NhsCtasId
             var nonMatchingResident = EntityHelpers.createResident(id: _faker.Random.Int(10, 1000));
+            nonMatchingResident.FirstName = matchingFirstName;
+            nonMatchingResident.LastName = matchingLastName;
 
             var nonMatchingHelpCase = EntityHelpers.createHelpRequestEntity(
                 id: _faker.Random.Int(100, 1000), // avoid potential inter-test clash

--- a/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/ResidentGatewayTest.cs
@@ -322,7 +322,6 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
 
             // confirm that the retrieved id was the one inserted
             returnedDuplicateResidentId.Should().Be(duplicateResident.Id);
-
         }
 
         // If NHS number rule fails to match &
@@ -951,6 +950,8 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
 
         #endregion
 
+        #region Patch, Update & Get
+
         [Test]
         public void PatchResidentReturnsTheUpdatedResident()
         {
@@ -1089,5 +1090,7 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             var response = _classUnderTest.GetResident(residentId);
             residentEntity.Should().BeEquivalentTo(response);
         }
+
+        #endregion
     }
 }

--- a/cv19ResSupportV3/V3/Domain/Commands/CreateResident.cs
+++ b/cv19ResSupportV3/V3/Domain/Commands/CreateResident.cs
@@ -25,5 +25,8 @@ namespace cv19ResSupportV3.V3.Domain.Commands
         public bool? ConsentToShare { get; set; }
         public string RecordStatus { get; set; }
         public string NhsNumber { get; set; }
+        // NhsCtasId is used for finding a duplicate record;
+        // it's not being stored on resident entity.
+        public string NhsCtasId { get; set; }
     }
 }

--- a/cv19ResSupportV3/V3/Domain/Commands/FindResident.cs
+++ b/cv19ResSupportV3/V3/Domain/Commands/FindResident.cs
@@ -42,5 +42,10 @@ namespace cv19ResSupportV3.V3.Domain.Commands
         /// </summary>
         /// <example>A1 2BC</example>
         public string Postcode { get; set; }
+        /// <summary>
+        /// Contact Tracing Number (8 character alphanumeral)
+        /// </summary>
+        /// <example>z1a238ff</example>
+        public string NhsCtasId { get; set; }
     }
 }

--- a/cv19ResSupportV3/V3/Domain/Commands/FindResident.cs
+++ b/cv19ResSupportV3/V3/Domain/Commands/FindResident.cs
@@ -38,6 +38,11 @@ namespace cv19ResSupportV3.V3.Domain.Commands
         /// <example>01</example>
         public string DobDay { get; set; }
         /// <summary>
+        /// Email address of the resident
+        /// </summary>
+        /// <example>someone@anywhere.tld</example>
+        public string EmailAddress { get; set; }
+        /// <summary>
         /// Postcode of the resident
         /// </summary>
         /// <example>A1 2BC</example>

--- a/cv19ResSupportV3/V3/Domain/Commands/FindResident.cs
+++ b/cv19ResSupportV3/V3/Domain/Commands/FindResident.cs
@@ -43,6 +43,16 @@ namespace cv19ResSupportV3.V3.Domain.Commands
         /// <example>someone@anywhere.tld</example>
         public string EmailAddress { get; set; }
         /// <summary>
+        /// Email address of the resident
+        /// </summary>
+        /// <example>7951721227</example>
+        public string ContactTelephoneNumber { get; set; }
+        /// <summary>
+        /// Email address of the resident
+        /// </summary>
+        /// <example>2077092577</example>
+        public string ContactMobileNumber { get; set; }
+        /// <summary>
         /// Postcode of the resident
         /// </summary>
         /// <example>A1 2BC</example>

--- a/cv19ResSupportV3/V3/Factories/Commands/CreateResidentFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/Commands/CreateResidentFactory.cs
@@ -29,6 +29,7 @@ namespace cv19ResSupportV3.V3.Factories.Commands
                 ConsentToShare = helpRequest.ConsentToShare,
                 RecordStatus = helpRequest.RecordStatus,
                 NhsNumber = helpRequest.NhsNumber,
+                NhsCtasId = helpRequest.NhsCtasId
             };
         }
     }

--- a/cv19ResSupportV3/V3/Factories/Commands/FindResidentFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/Commands/FindResidentFactory.cs
@@ -15,7 +15,8 @@ namespace cv19ResSupportV3.V3.Factories.Commands
                 DobYear = command.DobYear,
                 DobDay = command.DobDay,
                 Postcode = command.Postcode,
-                NhsNumber = command.NhsNumber
+                NhsNumber = command.NhsNumber,
+                NhsCtasId = command.NhsCtasId
             };
         }
     }

--- a/cv19ResSupportV3/V3/Factories/Commands/FindResidentFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/Commands/FindResidentFactory.cs
@@ -14,6 +14,7 @@ namespace cv19ResSupportV3.V3.Factories.Commands
                 DobMonth = command.DobMonth,
                 DobYear = command.DobYear,
                 DobDay = command.DobDay,
+                EmailAddress = command.EmailAddress,
                 Postcode = command.Postcode,
                 NhsNumber = command.NhsNumber,
                 NhsCtasId = command.NhsCtasId

--- a/cv19ResSupportV3/V3/Factories/Commands/FindResidentFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/Commands/FindResidentFactory.cs
@@ -15,6 +15,8 @@ namespace cv19ResSupportV3.V3.Factories.Commands
                 DobYear = command.DobYear,
                 DobDay = command.DobDay,
                 EmailAddress = command.EmailAddress,
+                ContactTelephoneNumber = command.ContactTelephoneNumber,
+                ContactMobileNumber = command.ContactMobileNumber,
                 Postcode = command.Postcode,
                 NhsNumber = command.NhsNumber,
                 NhsCtasId = command.NhsCtasId

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -234,7 +234,7 @@ namespace cv19ResSupportV3.V3.Gateways
                     {
                         var matchingResident = _helpRequestsContext.ResidentEntities
                             .FirstOrDefault(r =>
-                                r.EmailAddress == command.EmailAddress &&
+                                r.EmailAddress.Trim().ToUpper() == command.EmailAddress.Trim().ToUpper() &&
                                 r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
                                 r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
 

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -246,7 +246,7 @@ namespace cv19ResSupportV3.V3.Gateways
                     {
                         var matchingResident = _helpRequestsContext.ResidentEntities
                             .FirstOrDefault(r =>
-                                (r.ContactMobileNumber == command.ContactMobileNumber ||
+                                (r.ContactMobileNumber.Trim() == command.ContactMobileNumber.Trim() ||
                                 r.ContactTelephoneNumber == command.ContactMobileNumber) &&
                                 r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
                                 r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
@@ -259,7 +259,7 @@ namespace cv19ResSupportV3.V3.Gateways
                     {
                         var matchingResident = _helpRequestsContext.ResidentEntities
                             .FirstOrDefault(r =>
-                                (r.ContactTelephoneNumber == command.ContactTelephoneNumber ||
+                                (r.ContactTelephoneNumber.Trim() == command.ContactTelephoneNumber.Trim() ||
                                 r.ContactMobileNumber == command.ContactTelephoneNumber) &&
                                 r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
                                 r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -215,6 +215,20 @@ namespace cv19ResSupportV3.V3.Gateways
                         if (matchingResident != null)
                             return matchingResident.Id;
                     }
+
+                    if (Predicates.IsNotNullAndNotEmpty(command.NhsCtasId))
+                    {
+                        var matchingResident = _helpRequestsContext.ResidentEntities
+                            .Include(r => r.HelpRequests)
+                            .AsEnumerable()
+                            .FirstOrDefault(r =>
+                                r.HelpRequests.Exists(hr => hr.NhsCtasId == command.NhsCtasId) &&
+                                r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
+                                r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+
+                        if (matchingResident != null)
+                            return matchingResident.Id;
+                    }
                 }
 
                 return null;

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -246,7 +246,8 @@ namespace cv19ResSupportV3.V3.Gateways
                     {
                         var matchingResident = _helpRequestsContext.ResidentEntities
                             .FirstOrDefault(r =>
-                                r.ContactMobileNumber == command.ContactMobileNumber &&
+                                (r.ContactMobileNumber == command.ContactMobileNumber ||
+                                r.ContactTelephoneNumber == command.ContactMobileNumber) &&
                                 r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
                                 r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
 
@@ -258,7 +259,8 @@ namespace cv19ResSupportV3.V3.Gateways
                     {
                         var matchingResident = _helpRequestsContext.ResidentEntities
                             .FirstOrDefault(r =>
-                                r.ContactTelephoneNumber == command.ContactTelephoneNumber &&
+                                (r.ContactTelephoneNumber == command.ContactTelephoneNumber ||
+                                r.ContactMobileNumber == command.ContactTelephoneNumber) &&
                                 r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
                                 r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
 

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -247,7 +247,7 @@ namespace cv19ResSupportV3.V3.Gateways
                         var matchingResident = _helpRequestsContext.ResidentEntities
                             .FirstOrDefault(r =>
                                 (r.ContactMobileNumber.Trim() == command.ContactMobileNumber.Trim() ||
-                                r.ContactTelephoneNumber == command.ContactMobileNumber) &&
+                                r.ContactTelephoneNumber.Trim() == command.ContactMobileNumber.Trim()) &&
                                 r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
                                 r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
 
@@ -260,7 +260,7 @@ namespace cv19ResSupportV3.V3.Gateways
                         var matchingResident = _helpRequestsContext.ResidentEntities
                             .FirstOrDefault(r =>
                                 (r.ContactTelephoneNumber.Trim() == command.ContactTelephoneNumber.Trim() ||
-                                r.ContactMobileNumber == command.ContactTelephoneNumber) &&
+                                r.ContactMobileNumber.Trim() == command.ContactTelephoneNumber.Trim()) &&
                                 r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
                                 r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
 

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -241,6 +241,30 @@ namespace cv19ResSupportV3.V3.Gateways
                         if (matchingResident != null)
                             return matchingResident.Id;
                     }
+
+                    if (Predicates.IsNotNullAndNotEmpty(command.ContactMobileNumber))
+                    {
+                        var matchingResident = _helpRequestsContext.ResidentEntities
+                            .FirstOrDefault(r =>
+                                r.ContactMobileNumber == command.ContactMobileNumber &&
+                                r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
+                                r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+
+                        if (matchingResident != null)
+                            return matchingResident.Id;
+                    }
+
+                    if (Predicates.IsNotNullAndNotEmpty(command.ContactTelephoneNumber))
+                    {
+                        var matchingResident = _helpRequestsContext.ResidentEntities
+                            .FirstOrDefault(r =>
+                                r.ContactTelephoneNumber == command.ContactTelephoneNumber &&
+                                r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
+                                r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+
+                        if (matchingResident != null)
+                            return matchingResident.Id;
+                    }
                 }
 
                 return null;

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -222,7 +222,7 @@ namespace cv19ResSupportV3.V3.Gateways
                             .Include(r => r.HelpRequests)
                             .AsEnumerable()
                             .FirstOrDefault(r =>
-                                r.HelpRequests.Exists(hr => hr.NhsCtasId.ToUpper() == command.NhsCtasId.ToUpper()) &&
+                                r.HelpRequests.Exists(hr => hr.NhsCtasId.Trim().ToUpper() == command.NhsCtasId.Trim().ToUpper()) &&
                                 r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
                                 r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
 

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -222,7 +222,7 @@ namespace cv19ResSupportV3.V3.Gateways
                             .Include(r => r.HelpRequests)
                             .AsEnumerable()
                             .FirstOrDefault(r =>
-                                r.HelpRequests.Exists(hr => hr.NhsCtasId == command.NhsCtasId) &&
+                                r.HelpRequests.Exists(hr => hr.NhsCtasId.ToUpper() == command.NhsCtasId.ToUpper()) &&
                                 r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
                                 r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
 

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -169,13 +169,13 @@ namespace cv19ResSupportV3.V3.Gateways
         {
             try
             {
+                var residentsTable = _helpRequestsContext.ResidentEntities;
+
                 if (Predicates.IsNotNullAndNotEmpty(command.NhsNumber))
                 {
-                    var matchingResident = _helpRequestsContext.ResidentEntities
-                        .FirstOrDefault(r => r.NhsNumber.Replace(" ", "") == command.NhsNumber.Replace(" ", ""));
+                    var matchingResident = residentsTable.FirstOrDefault(r => r.NhsNumber.Replace(" ", "") == command.NhsNumber.Replace(" ", ""));
 
-                    if (matchingResident != null)
-                        return matchingResident.Id;
+                    if (matchingResident != null) return matchingResident.Id;
                 }
 
                 // If Fname or Lname are missing, no point checking Uprn or Dob. When these two fields
@@ -183,17 +183,17 @@ namespace cv19ResSupportV3.V3.Gateways
                 if (Predicates.IsNotNullAndNotEmpty(command.FirstName) &&
                     Predicates.IsNotNullAndNotEmpty(command.LastName))
                 {
+                    var matchingNameResidents = residentsTable.Where(r =>
+                        r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
+                        r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+
                     if (Predicates.IsNotNullAndNotEmpty(command.Uprn))
                     {
-                        var matchingResident = _helpRequestsContext.ResidentEntities
-                            .FirstOrDefault(r =>
-                                //uprn is all numbers, no need to change case
-                                r.Uprn.Trim() == command.Uprn.Trim() &&
-                                r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
-                                r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+                        var matchingResident = matchingNameResidents.FirstOrDefault(r =>
+                            //uprn is all numbers, no need to change case
+                            r.Uprn.Trim() == command.Uprn.Trim());
 
-                        if (matchingResident != null)
-                            return matchingResident.Id;
+                        if (matchingResident != null) return matchingResident.Id;
                     }
 
                     // Will ignore cases, where for instance DobYear and DobMonth are not empty, but DobDay is empty
@@ -203,69 +203,50 @@ namespace cv19ResSupportV3.V3.Gateways
                         Predicates.IsNotNullAndNotEmpty(command.DobMonth) &&
                         Predicates.IsNotNullAndNotEmpty(command.DobDay))
                     {
-                        var matchingResident = _helpRequestsContext.ResidentEntities
-                            .FirstOrDefault(r =>
-                                r.DobYear.Trim() == command.DobYear.Trim() &&
-                                // adding .ToUpper here in case month is specified with alphabetic characters for some cases (Jan, Dec)
-                                r.DobMonth.Trim().TrimStart('0').ToUpper() == command.DobMonth.Trim().TrimStart('0').ToUpper() &&
-                                r.DobDay.Trim().TrimStart('0') == command.DobDay.Trim().TrimStart('0') &&
-                                r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
-                                r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+                        var matchingResident = matchingNameResidents.FirstOrDefault(r =>
+                            r.DobYear.Trim() == command.DobYear.Trim() &&
+                            // adding .ToUpper here in case month is specified with alphabetic characters for some cases (Jan, Dec)
+                            r.DobMonth.Trim().TrimStart('0').ToUpper() == command.DobMonth.Trim().TrimStart('0').ToUpper() &&
+                            r.DobDay.Trim().TrimStart('0') == command.DobDay.Trim().TrimStart('0'));
 
-                        if (matchingResident != null)
-                            return matchingResident.Id;
+                        if (matchingResident != null) return matchingResident.Id;
                     }
 
                     if (Predicates.IsNotNullAndNotEmpty(command.NhsCtasId))
                     {
-                        var matchingResident = _helpRequestsContext.ResidentEntities
+                        var matchingResident = matchingNameResidents
                             .Include(r => r.HelpRequests)
                             .AsEnumerable()
                             .FirstOrDefault(r =>
-                                r.HelpRequests.Exists(hr => hr.NhsCtasId.Trim().ToUpper() == command.NhsCtasId.Trim().ToUpper()) &&
-                                r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
-                                r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+                                r.HelpRequests.Exists(hr => hr.NhsCtasId.Trim().ToUpper() == command.NhsCtasId.Trim().ToUpper()));
 
-                        if (matchingResident != null)
-                            return matchingResident.Id;
+                        if (matchingResident != null) return matchingResident.Id;
                     }
 
                     if (Predicates.IsNotNullAndNotEmpty(command.EmailAddress))
                     {
-                        var matchingResident = _helpRequestsContext.ResidentEntities
-                            .FirstOrDefault(r =>
-                                r.EmailAddress.Trim().ToUpper() == command.EmailAddress.Trim().ToUpper() &&
-                                r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
-                                r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+                        var matchingResident = matchingNameResidents.FirstOrDefault(r =>
+                            r.EmailAddress.Trim().ToUpper() == command.EmailAddress.Trim().ToUpper());
 
-                        if (matchingResident != null)
-                            return matchingResident.Id;
+                        if (matchingResident != null) return matchingResident.Id;
                     }
 
                     if (Predicates.IsNotNullAndNotEmpty(command.ContactMobileNumber))
                     {
-                        var matchingResident = _helpRequestsContext.ResidentEntities
-                            .FirstOrDefault(r =>
-                                (r.ContactMobileNumber.Trim() == command.ContactMobileNumber.Trim() ||
-                                r.ContactTelephoneNumber.Trim() == command.ContactMobileNumber.Trim()) &&
-                                r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
-                                r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+                        var matchingResident = matchingNameResidents.FirstOrDefault(r =>
+                            r.ContactMobileNumber.Trim() == command.ContactMobileNumber.Trim() ||
+                            r.ContactTelephoneNumber.Trim() == command.ContactMobileNumber.Trim());
 
-                        if (matchingResident != null)
-                            return matchingResident.Id;
+                        if (matchingResident != null) return matchingResident.Id;
                     }
 
                     if (Predicates.IsNotNullAndNotEmpty(command.ContactTelephoneNumber))
                     {
-                        var matchingResident = _helpRequestsContext.ResidentEntities
-                            .FirstOrDefault(r =>
-                                (r.ContactTelephoneNumber.Trim() == command.ContactTelephoneNumber.Trim() ||
-                                r.ContactMobileNumber.Trim() == command.ContactTelephoneNumber.Trim()) &&
-                                r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
-                                r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+                        var matchingResident = matchingNameResidents.FirstOrDefault(r =>
+                            r.ContactTelephoneNumber.Trim() == command.ContactTelephoneNumber.Trim() ||
+                            r.ContactMobileNumber.Trim() == command.ContactTelephoneNumber.Trim());
 
-                        if (matchingResident != null)
-                            return matchingResident.Id;
+                        if (matchingResident != null) return matchingResident.Id;
                     }
                 }
 

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -229,6 +229,18 @@ namespace cv19ResSupportV3.V3.Gateways
                         if (matchingResident != null)
                             return matchingResident.Id;
                     }
+
+                    if (Predicates.IsNotNullAndNotEmpty(command.EmailAddress))
+                    {
+                        var matchingResident = _helpRequestsContext.ResidentEntities
+                            .FirstOrDefault(r =>
+                                r.EmailAddress == command.EmailAddress &&
+                                r.FirstName.Trim().ToUpper() == command.FirstName.Trim().ToUpper() &&
+                                r.LastName.Trim().ToUpper() == command.LastName.Trim().ToUpper());
+
+                        if (matchingResident != null)
+                            return matchingResident.Id;
+                    }
                 }
 
                 return null;


### PR DESCRIPTION
# What
- Added NhsCtasId de-duplication rule.
- Added Email Address de-duplication rule.
- Added Mobile number de-duplication rule.
- Added Landline number de-duplication rule.
- Ensured the checks are made in trim&case-insensitive way where needed.
- Single Phone number is checked against both fields.

# Why
- There are still a few records coming in through data ingestion process that do not have enough information for them to be identifiable.

# Link to ticket
Jira Ticket: [39](https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=64&projectKey=HTHD&modal=detail&selectedIssue=HTHD-39).

# Notes
Couldn't reduce the size of the implementation code further in this time frame, because C# and EF Core are poorly programmed. To give examples:
- Predicate<T\> is the same thing as Func<T, bool>, yet they're made to function differently and don't parse from one to other, leading to compilation errors. It makes 0 sense for them to be different things.
- In EF Core, when you have a fine working statement .Where(r => r.something.dostuff() == c.something.dostuff()), then if you extract the expression into function and call it: .Where(r => checkfunction(r)), then it fails to be parsed by EF Core. Ridiculous! Why can't the ORM make the proper substitution before compiling to postgresql? Who knows? Apparently they want you slapping .AsEnumerable left and right shifting the computation to the app itself.

