### PR TITLE
Prevent duplicate generic help types

### DIFF
--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -89,6 +89,35 @@ namespace cv19ResSupportV3.V3.Gateways
             }
         }
 
+        public int? FindHelpRequestByMetadataAndResidentId(string propertyName, dynamic metadata, int residentId)
+        {
+            string propertyInfo;
+
+            try
+            {
+                propertyInfo = metadata.GetProperty(propertyName).ToString();
+            }
+            catch (Exception e)
+            {
+                return null;
+            };
+
+            try
+            {
+                var helpRequestEntity = _helpRequestsContext.HelpRequestEntities
+                    .FromSqlRaw("select * from help_requests WHERE metadata->>{0} LIKE {1}", propertyName, propertyInfo)
+                    .FirstOrDefault(x => x.ResidentId == residentId);
+
+                return helpRequestEntity?.Id;
+            }
+            catch (Exception e)
+            {
+                LambdaLogger.Log("FindHelpRequestByMetadata error: ");
+                LambdaLogger.Log(e.Message);
+                throw;
+            }
+        }
+
         public List<LookupDomain> GetLookups(LookupQuery command)
         {
             Expression<Func<LookupEntity, bool>> queryLookups = x =>

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -112,7 +112,7 @@ namespace cv19ResSupportV3.V3.Gateways
             }
             catch (Exception e)
             {
-                LambdaLogger.Log("FindHelpRequestByMetadata error: ");
+                LambdaLogger.Log("FindHelpRequestByMetadataAndResidentId error: ");
                 LambdaLogger.Log(e.Message);
                 throw;
             }

--- a/cv19ResSupportV3/V3/Gateways/IHelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/IHelpRequestGateway.cs
@@ -10,6 +10,7 @@ namespace cv19ResSupportV3.V3.Gateways
         int CreateHelpRequest(int residentId, CreateHelpRequest command);
         int? FindHelpRequestByCtasId(string ctasId, string helpNeeded);
         int? FindHelpRequestByMetadata(string propertyName, dynamic metadata);
+        int? FindHelpRequestByMetadataAndResidentId(string propertyName, dynamic metadata, int residentId);
         List<LookupDomain> GetLookups(LookupQuery command);
         HelpRequest UpdateHelpRequest(int id, UpdateHelpRequest command);
         HelpRequest PatchHelpRequest(int id, PatchHelpRequest command);

--- a/cv19ResSupportV3/V3/UseCase/CreateHelpRequestUseCase.cs
+++ b/cv19ResSupportV3/V3/UseCase/CreateHelpRequestUseCase.cs
@@ -22,6 +22,9 @@ namespace cv19ResSupportV3.V3.UseCase
             helpRequestId = _gateway.FindHelpRequestByMetadata("spl_id", command.Metadata);
             if (helpRequestId != null) { return (int) helpRequestId; }
 
+            helpRequestId = _gateway.FindHelpRequestByMetadataAndResidentId("generic_ingestion_id", command.Metadata, residentId);
+            if (helpRequestId != null) { return (int) helpRequestId; }
+
             return _gateway.CreateHelpRequest(residentId, command);
         }
     }


### PR DESCRIPTION
# What
Added the ability to prevent an ingest creating a duplicate help request for a resident by applying a generic ingest id. This will be set to the help request type at present.

# Why
Without this, every time a generic ingest is run for 'EUSS' help requests, it will create duplicate requests against a resident. By setting the generic ingest id to 'euss' we prevent duplicates, and can remove/make unique for any types that require multiple.


