### PR TITLE
Added help needed to the return object from create case note.

### DIFF
--- a/cv19ResSupportV3/V3/Gateways/CaseNotesGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/CaseNotesGateway.cs
@@ -62,6 +62,8 @@ namespace cv19ResSupportV3.V3.Gateways
                 _helpRequestsContext.CaseNoteEntities.Add(rec);
                 _helpRequestsContext.SaveChanges();
 
+                rec.HelpRequestEntity = _helpRequestsContext.HelpRequestEntities.FirstOrDefault(x => x.Id == helpRequestId);
+
                 return rec.ToDomain();
             }
             catch (Exception e)


### PR DESCRIPTION
# What

Added help needed to the response from create case notes.

# Why

This response is consumed by the ingest and the null value for helpNeeded caused a background error. It was decided it's better to populate the full object in the return rather than remove the parsing error as it provides more data to validate.

The helpNeeded was added to case notes object to allow this data to be filtered by the a specific help type.

