### PR TITLE
Readme update incl. removing manual steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ This is the API for the third iteration of the resident support request service.
 
 ### Development
 
-To serve the application, run it using your IDE of choice, we use Visual Studio CE and JetBrains Rider on Mac.
+This application is a Visual Studio solution built with C#. It uses Entity Framework.
+Visual Studio or Rider are therefore recommended over VS Code.
+Debugging and Entity Framework migrations will potentially require more steps than below for other IDEs.
 
 The application can also be served locally using docker:
 1.  Add you security credentials to AWS CLI.
@@ -35,7 +37,21 @@ $ aws ecr get-login --no-include-email
 $ make build && make serve
 ```
 
-See further information in [here](./docs/Development.md).
+This will initialise the API on port 3000.
+This may conflict with other applications, it also doesn't provide full debugging capabilities of Visual Studio.
+
+4. Ensure Docker is started and the appSettings connection string matches the cv-19-res-support-v3_dev_database values, which should also be running in Docker.
+
+5. In your Visual Studio/IDE Terminal your current directory should be cv19ResSupportV3.
+
+6. Now apply all migrations: This command is for Visual Studio / Mac. 
+```sh
+$ dotnet ef database update
+```
+
+You can now run the application in full debug mode which will open it on port 5001, allowing breakpoints to be added and hit.
+
+See further information in [here](./docs/Development.md) which contains information on using a development database in AWS.
 
 ### Release process
 
@@ -72,12 +88,6 @@ Documentation on how to do this can be found [here](https://docs.microsoft.com/e
 ```sh
 $ make test
 ```
-
-To run database tests locally (e.g. via Visual Studio) the `CONNECTION_STRING` environment variable will need to be populated with:
-
-`Host=localhost;Database=entitycore;Username=postgres;Password=mypassword"`
-
-Note: The Host name needs to be the name of the stub database docker-compose service, in order to run tests via Docker.
 
 ### Agreed Testing Approach
 - Use nUnit, FluentAssertions and Moq

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This may conflict with other applications, it also doesn't provide full debuggin
 
 4. Ensure Docker is started and the appSettings connection string matches the cv-19-res-support-v3_dev_database values, which should also be running in Docker.
 
-5. In your Visual Studio/IDE Terminal your current directory should be cv19ResSupportV3.
+5. In your Visual Studio/IDE Terminal your current directory should be cv19ResSupportV3 which contains the main .csproj file.
 
 6. Now apply all migrations: This command is for Visual Studio / Mac. 
 ```sh

--- a/cv19ResSupportV3.Tests/ConnectionString.cs
+++ b/cv19ResSupportV3.Tests/ConnectionString.cs
@@ -7,10 +7,10 @@ namespace cv19ResSupportV3.Tests
         public static string TestDatabase()
         {
             return $"Host={Environment.GetEnvironmentVariable("DB_HOST") ?? "127.0.0.1"};" +
-                   $"Port={Environment.GetEnvironmentVariable("DB_PORT") ?? "5433"};" +
+                   $"Port={Environment.GetEnvironmentVariable("DB_PORT") ?? "5432"};" +
                    $"Username={Environment.GetEnvironmentVariable("DB_USERNAME") ?? "postgres"};" +
                    $"Password={Environment.GetEnvironmentVariable("DB_PASSWORD") ?? "mypassword"};" +
-                   $"Database={Environment.GetEnvironmentVariable("DB_DATABASE") ?? "devdb"}";
+                   $"Database={Environment.GetEnvironmentVariable("DB_DATABASE") ?? "testdb"}";
         }
     }
 }

--- a/cv19ResSupportV3.Tests/ConnectionString.cs
+++ b/cv19ResSupportV3.Tests/ConnectionString.cs
@@ -7,10 +7,10 @@ namespace cv19ResSupportV3.Tests
         public static string TestDatabase()
         {
             return $"Host={Environment.GetEnvironmentVariable("DB_HOST") ?? "127.0.0.1"};" +
-                   $"Port={Environment.GetEnvironmentVariable("DB_PORT") ?? "5432"};" +
+                   $"Port={Environment.GetEnvironmentVariable("DB_PORT") ?? "5433"};" +
                    $"Username={Environment.GetEnvironmentVariable("DB_USERNAME") ?? "postgres"};" +
                    $"Password={Environment.GetEnvironmentVariable("DB_PASSWORD") ?? "mypassword"};" +
-                   $"Database={Environment.GetEnvironmentVariable("DB_DATABASE") ?? "testdb"}";
+                   $"Database={Environment.GetEnvironmentVariable("DB_DATABASE") ?? "devdb"}";
         }
     }
 }

--- a/cv19ResSupportV3/Startup.cs
+++ b/cv19ResSupportV3/Startup.cs
@@ -35,7 +35,7 @@ namespace cv19ResSupportV3
         private const string ApiName = "cv-19-resident-support";
 
         // This method gets called by the runtime. Use this method to add services to the container.
-        public static void ConfigureServices(IServiceCollection services)
+        public void ConfigureServices(IServiceCollection services)
         {
             services
                 .AddMvc(setupAction =>
@@ -128,9 +128,13 @@ namespace cv19ResSupportV3
             RegisterUseCases(services);
         }
 
-        private static void ConfigureDbContext(IServiceCollection services)
+        private void ConfigureDbContext(IServiceCollection services)
         {
+#if DEBUG
+            var connectionString = Configuration.GetConnectionString("DevDocker");
+#else
             var connectionString = Environment.GetEnvironmentVariable("CONNECTION_STRING");
+#endif
 
             if (connectionString != null && !connectionString.Contains("CommandTimeout")) { connectionString += $";CommandTimeout=900"; }
 

--- a/cv19ResSupportV3/appsettings.Development.json
+++ b/cv19ResSupportV3/appsettings.Development.json
@@ -5,5 +5,8 @@
       "System": "Information",
       "Microsoft": "Information"
     }
+  },
+  "ConnectionStrings": {
+    "DevDocker": "Host=127.0.0.1;Port=5433;Username=postgres;Password=mypassword;Database=devdb"
   }
 }


### PR DESCRIPTION
# What
- Updated Readme to include Entity Framework migrations and setup required to achieve:
1.  Debug in VS (make serve doesn't get you to breakpoints).
2. All tests pass, including database-connected tests.

# Why
The existing Readme got to the point of building but not debugging, and it wasn't clear how to get all tests successfully running against a local database.

# Notes
- Changed local connection string implementation to avoid having to create environment variables locally (has issues on MacBook).

- Removed steps no longer needed from Readme.

