### PR TITLE
Change dev connection string implementation:

### DIFF
--- a/cv19ResSupportV3/Startup.cs
+++ b/cv19ResSupportV3/Startup.cs
@@ -130,10 +130,13 @@ namespace cv19ResSupportV3
 
         private void ConfigureDbContext(IServiceCollection services)
         {
-#if DEBUG
-            var connectionString = Configuration.GetConnectionString("DevDocker");
-#else
             var connectionString = Environment.GetEnvironmentVariable("CONNECTION_STRING");
+
+#if DEBUG
+            if (connectionString == null)
+            {
+                connectionString = Configuration.GetConnectionString("DevDocker");
+            }
 #endif
 
             if (connectionString != null && !connectionString.Contains("CommandTimeout")) { connectionString += $";CommandTimeout=900"; }


### PR DESCRIPTION
It will now always check the environment variable first, as some people may be using this already. This will also ensure any CircleCI / dev environments that use it function. The appSetting value is then a backup for DEBUG environments that do not have an environment variable available.


