### PR TITLE
Call handlers - move to DB/API

### DIFF
--- a/cv19ResSupportV3.Tests/DatabaseTests.cs
+++ b/cv19ResSupportV3.Tests/DatabaseTests.cs
@@ -39,6 +39,8 @@ namespace cv19ResSupportV3.Tests
             DatabaseContext.HelpRequestCallEntities.RemoveRange(addedCalls);
             var addedEntities = DatabaseContext.HelpRequestEntities;
             DatabaseContext.HelpRequestEntities.RemoveRange(addedEntities);
+            var addedCallHandlers = DatabaseContext.CallHandlerEntities;
+            DatabaseContext.CallHandlerEntities.RemoveRange(addedCallHandlers);
             var addedLookups = DatabaseContext.Lookups;
             DatabaseContext.Lookups.RemoveRange(addedLookups);
             try

--- a/cv19ResSupportV3.Tests/V3/E2ETests/PatchHelpRequest.cs
+++ b/cv19ResSupportV3.Tests/V3/E2ETests/PatchHelpRequest.cs
@@ -187,9 +187,8 @@ namespace cv19ResSupportV3.Tests.V3.E2ETests
             statusCode.Should().Be(200);
             var content = response.Result.Content;
             var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
-            var convertedResponse = JsonConvert.DeserializeObject<HelpRequestCreateResponse>(stringContent);
             var updatedEntity = DatabaseContext.HelpRequestEntities.First();
-            updatedEntity.AssignedTo.Should().BeEquivalentTo(changeValue);
+            updatedEntity.CallHandlerEntity.Name.Should().BeEquivalentTo(changeValue);
         }
     }
 }

--- a/cv19ResSupportV3.Tests/V3/E2ETests/UpdateStaffAssignments.cs
+++ b/cv19ResSupportV3.Tests/V3/E2ETests/UpdateStaffAssignments.cs
@@ -32,7 +32,7 @@ namespace cv19ResSupportV3.Tests.V3.E2ETests
         {
             var residentEntity = DatabaseContext.ResidentEntities.Add(EntityHelpers.createResident());
             var helpRequestEntity = DatabaseContext.HelpRequestEntities.Add(EntityHelpers.createHelpRequestEntity(123, residentEntity.Entity.Id));
-            helpRequestEntity.Entity.AssignedTo = null;
+            helpRequestEntity.Entity.CallHandlerEntity = null;
             helpRequestEntity.Entity.HelpNeeded = "Help Request";
             helpRequestEntity.Entity.CallbackRequired = true;
             helpRequestEntity.Entity.InitialCallbackCompleted = false;

--- a/cv19ResSupportV3.Tests/V3/Factories/Commands/CreateHelpRequestFactoryTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Factories/Commands/CreateHelpRequestFactoryTest.cs
@@ -17,7 +17,11 @@ namespace cv19ResSupportV3.Tests.V3.Factories.Commands
         {
             var entity = _fixture.Build<CreateHelpRequest>().Create();
             var command = entity.ToEntity();
-            command.Should().BeEquivalentTo(entity);
+            command.Should().BeEquivalentTo(entity, options =>
+            {
+                options.Excluding(ex => ex.AssignedTo);
+                return options;
+            });
             command.Should().BeOfType<HelpRequestEntity>();
         }
         [Test]

--- a/cv19ResSupportV3.Tests/V3/Factories/HelpRequestFactoryTest.cs
+++ b/cv19ResSupportV3.Tests/V3/Factories/HelpRequestFactoryTest.cs
@@ -16,6 +16,7 @@ namespace cv19ResSupportV3.Tests.V3.Factories
             entityObject.Should().BeEquivalentTo(domainObject, options =>
             {
                 options.Excluding(x => x.CaseNotes);
+                options.Excluding(x => x.AssignedTo);
                 return options;
             });
         }

--- a/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
@@ -137,6 +137,8 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             {
                 options.Excluding(ex => ex.CaseNotes);
                 options.Excluding(ex => ex.ResidentEntity);
+                options.Excluding(ex => ex.CallHandlerEntity);
+                options.Excluding(ex => ex.CallHandlerId);
                 return options;
             });
         }

--- a/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
+++ b/cv19ResSupportV3.Tests/V3/Gateways/HelpRequestGatewayTests.cs
@@ -196,6 +196,8 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             {
                 options.Excluding(x => x.CaseNotes);
                 options.Excluding(x => x.ResidentEntity);
+                options.Excluding(x => x.CallHandlerEntity);
+                options.Excluding(x => x.CallHandlerId);
                 return options;
             });
 
@@ -228,6 +230,8 @@ namespace cv19ResSupportV3.Tests.V3.Gateways
             {
                 options.Excluding(x => x.CaseNotes);
                 options.Excluding(x => x.ResidentEntity);
+                options.Excluding(x => x.CallHandlerEntity);
+                options.Excluding(x => x.CallHandlerId);
                 return options;
             });
         }

--- a/cv19ResSupportV3.Tests/V3/Helpers/EntityHelpers.cs
+++ b/cv19ResSupportV3.Tests/V3/Helpers/EntityHelpers.cs
@@ -24,9 +24,11 @@ namespace cv19ResSupportV3.Tests.V3.Helpers
                 .With(x => x.ResidentId, residentId)
                 .With(x => x.HelpNeeded, helpNeeded)
                 .With(x => x.HelpNeededSubtype, helpNeededSubtype)
+                .Without(x => x.CallHandlerId)
                 .Without(h => h.HelpRequestCalls)
                 .Without(h => h.CaseNotes)
                 .Without(h => h.ResidentEntity)
+                .Without(h => h.CallHandlerEntity)
                 .Create();
             return helpRequestEntity;
         }
@@ -37,6 +39,8 @@ namespace cv19ResSupportV3.Tests.V3.Helpers
                 .Without(h => h.HelpRequestCalls)
                 .Without(h => h.CaseNotes)
                 .Without(h => h.ResidentEntity)
+                .Without(h => h.CallHandlerEntity)
+                .Without(h => h.CallHandlerId)
                 .With(x => x.ResidentId, residentId)
                 .CreateMany(count)
                 .ToList();

--- a/cv19ResSupportV3.Tests/V3/Helpers/FactoryHelper.cs
+++ b/cv19ResSupportV3.Tests/V3/Helpers/FactoryHelper.cs
@@ -73,7 +73,7 @@ namespace cv19ResSupportV3.Tests.V3.Helpers
                 HelpNeededSubtype = helpRequest.HelpNeededSubtype,
                 NhsNumber = resident.NhsNumber,
                 NhsCtasId = helpRequest.NhsCtasId,
-                AssignedTo = helpRequest.AssignedTo
+                AssignedTo = helpRequest.CallHandlerEntity?.Name
             };
         }
     }

--- a/cv19ResSupportV3.Tests/V4/Controllers/CallHandlersControllerTests.cs
+++ b/cv19ResSupportV3.Tests/V4/Controllers/CallHandlersControllerTests.cs
@@ -1,0 +1,39 @@
+using AutoFixture;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Domain.Commands;
+using cv19ResSupportV3.V4.UseCase.Interfaces;
+using cv19ResSupportV3.V4;
+using cv19ResSupportV3.V4.Controllers;
+using cv19ResSupportV3.V4.UseCase.Interface;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace cv19ResSupportV3.Tests.V4.Controllers
+{
+    [TestFixture]
+    public class CallHandlersControllerTests
+    {
+        private CallHandlersController _classUnderTest;
+        private Mock<IGetCallHandlersUseCase> _getCallHandlersUseCase;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _getCallHandlersUseCase = new Mock<IGetCallHandlersUseCase>();
+            _classUnderTest = new CallHandlersController(_getCallHandlersUseCase.Object);
+        }
+
+        [Test]
+        public void GetReturnsResponseWithStatus()
+        {
+            var response = new Fixture().Build<List<CallHandlerResponseBoundary>>().Create();
+            _getCallHandlersUseCase.Setup(uc => uc.Execute())
+                .Returns(response);
+            var result = _classUnderTest.GetCallHandlers() as OkObjectResult;
+            result.StatusCode.Should().Be(200);
+        }
+    }
+}

--- a/cv19ResSupportV3.Tests/V4/UseCases/GetCallHandlersUseCaseTests.cs
+++ b/cv19ResSupportV3.Tests/V4/UseCases/GetCallHandlersUseCaseTests.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using AutoFixture;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Domain.Commands;
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V4;
+using cv19ResSupportV3.V4.Factories;
+using cv19ResSupportV3.V4.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace cv19ResSupportV3.Tests.V4.UseCases
+{
+    [TestFixture]
+    public class GetCallHandlersUseCaseTests
+    {
+        private Mock<ICallHandlerGateway> _mockGateway;
+        private GetCallHandlersUseCase _classUnderTest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockGateway = new Mock<ICallHandlerGateway>();
+            _classUnderTest = new GetCallHandlersUseCase(_mockGateway.Object);
+        }
+
+        [Test]
+        public void ExecuteMethodCallsCallHandlerGateway()
+        {
+            var gatewayResponse = new Fixture().Build<List<CallHandler>>().Create();
+            _mockGateway.Setup(gw => gw.GetCallHandlers()).Returns(gatewayResponse);
+            var response = _classUnderTest.Execute();
+            _mockGateway.Verify(uc => uc.GetCallHandlers(), Times.Once);
+            response.Should().BeEquivalentTo(gatewayResponse.ToResponse());
+        }
+
+    }
+}

--- a/cv19ResSupportV3.Tests/cv19ResSupportV3.Tests.csproj
+++ b/cv19ResSupportV3.Tests/cv19ResSupportV3.Tests.csproj
@@ -30,7 +30,6 @@
   <ItemGroup>
     <Content Update="Properties\launchSettings.json">
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </Content>
   </ItemGroup>

--- a/cv19ResSupportV3/Startup.cs
+++ b/cv19ResSupportV3/Startup.cs
@@ -150,6 +150,7 @@ namespace cv19ResSupportV3
             services.AddScoped<IHelpRequestGateway, HelpRequestGateway>();
             services.AddScoped<IHelpRequestCallGateway, HelpRequestCallGateway>();
             services.AddScoped<IResidentGateway, ResidentGateway>();
+            services.AddScoped<ICallHandlerGateway, CallHandlerGateway>();
             services.AddScoped<ICaseNotesGateway, CaseNotesGateway>();
         }
 
@@ -183,6 +184,7 @@ namespace cv19ResSupportV3
             services.AddScoped<IPatchResidentHelpRequestUseCase, PatchResidentHelpRequestUseCase>();
             services.AddScoped<IGetCaseNotesByResidentIdUseCase, GetCaseNotesByResidentIdUseCase>();
             services.AddScoped<IGetCaseNotesByHelpRequestIdUseCase, GetCaseNotesByHelpRequestIdUseCase>();
+            services.AddScoped<IGetCallHandlersUseCase, GetCallHandlersUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/cv19ResSupportV3/V3/Domain/CallHandler.cs
+++ b/cv19ResSupportV3/V3/Domain/CallHandler.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace cv19ResSupportV3.V3.Domain
+{
+    public class CallHandler
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/cv19ResSupportV3/V3/Factories/Commands/CreateHelpRequestFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/Commands/CreateHelpRequestFactory.cs
@@ -50,7 +50,6 @@ namespace cv19ResSupportV3.V3.Factories.Commands
                 HelpNeeded = helpRequest.HelpNeeded,
                 HelpNeededSubtype = helpRequest.HelpNeededSubtype,
                 NhsCtasId = helpRequest.NhsCtasId,
-                AssignedTo = helpRequest.AssignedTo,
                 HelpRequestCalls = helpRequest.HelpRequestCalls.ToEntity()
             };
         }

--- a/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/HelpRequestFactory.cs
@@ -54,7 +54,7 @@ namespace cv19ResSupportV3.V3.Factories
                 HelpNeededSubtype = helpRequest.HelpNeededSubtype,
                 Metadata = helpRequest.Metadata,
                 NhsCtasId = helpRequest.NhsCtasId,
-                AssignedTo = helpRequest.AssignedTo,
+                AssignedTo = helpRequest.CallHandlerEntity?.Name,
             };
         }
         public static Resident ToDomain(this ResidentEntity resident)

--- a/cv19ResSupportV3/V3/Factories/HelpRequestWithResidentFactory.cs
+++ b/cv19ResSupportV3/V3/Factories/HelpRequestWithResidentFactory.cs
@@ -77,7 +77,7 @@ namespace cv19ResSupportV3.V3.Factories
                 HelpNeededSubtype = helpRequest.HelpNeededSubtype,
                 NhsCtasId = helpRequest.NhsCtasId,
                 NhsNumber = helpRequest.ResidentEntity.NhsNumber,
-                AssignedTo = helpRequest.AssignedTo,
+                AssignedTo = helpRequest.CallHandlerEntity?.Name,
                 Metadata = helpRequest.Metadata,
                 HelpRequestCalls = helpRequest.HelpRequestCalls.ToDomain()
             };

--- a/cv19ResSupportV3/V3/Gateways/CallHandlerGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/CallHandlerGateway.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Amazon.Lambda.Core;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Domain.Commands;
+using cv19ResSupportV3.V4.Factories;
+using cv19ResSupportV3.V3.Infrastructure;
+using cv19ResSupportV3.V4.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace cv19ResSupportV3.V3.Gateways
+{
+    public class CallHandlerGateway : ICallHandlerGateway
+    {
+        private readonly HelpRequestsContext _helpRequestsContext;
+
+        public CallHandlerGateway(HelpRequestsContext helpRequestsContext)
+        {
+            _helpRequestsContext = helpRequestsContext;
+        }
+
+        public List<CallHandler> GetCallHandlers()
+        {
+            try
+            {
+                var response = _helpRequestsContext.CallHandlerEntities
+                    .Select(ch => ch.ToDomain()).ToList();
+                return response;
+            }
+            catch (Exception e)
+            {
+                LambdaLogger.Log("GetCallHandlers error: ");
+                LambdaLogger.Log(e.Message);
+                throw;
+            }
+        }
+    }
+}

--- a/cv19ResSupportV3/V3/Gateways/CallHandlerGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/CallHandlerGateway.cs
@@ -1,14 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using Amazon.Lambda.Core;
 using cv19ResSupportV3.V3.Domain;
-using cv19ResSupportV3.V3.Domain.Commands;
 using cv19ResSupportV3.V4.Factories;
 using cv19ResSupportV3.V3.Infrastructure;
-using cv19ResSupportV3.V4.Helpers;
-using Microsoft.EntityFrameworkCore;
 
 namespace cv19ResSupportV3.V3.Gateways
 {

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -336,6 +336,12 @@ namespace cv19ResSupportV3.V3.Gateways
                     rec.HelpNeeded = command.HelpNeeded;
                 }
 
+                var assignedToHandler =
+                    _helpRequestsContext.CallHandlerEntities.FirstOrDefault(x => x.Name == command.AssignedTo);
+
+                rec.CallHandlerId = assignedToHandler?.Id;
+                rec.AssignedTo = assignedToHandler?.Name;
+
                 _helpRequestsContext.SaveChanges();
             }
             catch (Exception e)

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -167,6 +167,7 @@ namespace cv19ResSupportV3.V3.Gateways
                     .Include(x => x.HelpRequestCalls)
                     .Include(x => x.ResidentEntity)
                     .Include(x => x.CaseNotes)
+                    .Include(x => x.CallHandlerEntity)
                     .FirstOrDefault(x => x.Id == id);
                 return helpRequest?.ToHelpRequestWithResidentDomain();
             }
@@ -206,6 +207,7 @@ namespace cv19ResSupportV3.V3.Gateways
                     .Include(x => x.HelpRequestCalls)
                     .Include(x => x.CaseNotes)
                     .Include(x => x.ResidentEntity)
+                    .Include(x => x.CallHandlerEntity)
                     .Where(queryPostcode)
                     .Where(queryFirstName)
                     .Where(queryLastName)
@@ -328,19 +330,15 @@ namespace cv19ResSupportV3.V3.Gateways
 
                 if (command.AssignedTo != null)
                 {
-                    rec.AssignedTo = command.AssignedTo;
+                    rec.CallHandlerId =
+                        _helpRequestsContext.CallHandlerEntities.FirstOrDefault(x => x.Name == command.AssignedTo)
+                        ?.Id;
                 }
 
                 if (command.HelpNeeded != null)
                 {
                     rec.HelpNeeded = command.HelpNeeded;
                 }
-
-                var assignedToHandler =
-                    _helpRequestsContext.CallHandlerEntities.FirstOrDefault(x => x.Name == command.AssignedTo);
-
-                rec.CallHandlerId = assignedToHandler?.Id;
-                rec.AssignedTo = assignedToHandler?.Name;
 
                 _helpRequestsContext.SaveChanges();
             }
@@ -364,6 +362,7 @@ namespace cv19ResSupportV3.V3.Gateways
             {
                 var response = _helpRequestsContext.HelpRequestEntities.Include(x => x.HelpRequestCalls)
                     .Include(x => x.ResidentEntity)
+                    .Include(x => x.CallHandlerEntity)
                     .Include(x => x.CaseNotes)
                     .Where(x => (x.CallbackRequired == true || x.CallbackRequired == null ||
                                  (x.InitialCallbackCompleted == false && x.CallbackRequired == false)))
@@ -388,6 +387,7 @@ namespace cv19ResSupportV3.V3.Gateways
                 var helpRequests = _helpRequestsContext.HelpRequestEntities
                     .Include(x => x.HelpRequestCalls)
                     .Include(x => x.ResidentEntity)
+                    .Include(x => x.CallHandlerEntity)
                     .Include(x => x.CaseNotes)
                     .Where(x => x.ResidentId == id);
                 return helpRequests.Select(hr => hr.ToHelpRequestWithResidentDomain()).ToList();
@@ -399,32 +399,5 @@ namespace cv19ResSupportV3.V3.Gateways
                 throw;
             }
         }
-
-        //        private void SetRecordStatus(HelpRequestEntityOld request)
-        //        {
-        //            request.RecordStatus = "MASTER";
-        //            var duplicates = _helpRequestsContext.HelpRequestEntities
-        //                .Where(x => x.Uprn == request.Uprn && x.DobMonth == request.DobMonth
-        //                                                   && x.DobDay == request.DobDay && x.DobYear == request.DobYear &&
-        //                                                   x.ContactTelephoneNumber == request.ContactTelephoneNumber &&
-        //                                                   x.ContactMobileNumber == request.ContactMobileNumber).ToList();
-        //            if (duplicates.Count > 0)
-        //            {
-        //                foreach (var record in duplicates)
-        //                {
-        //                    var rec = _helpRequestsContext.HelpRequestEntities.Find(record.Id);
-        //                    rec.RecordStatus = "DUPLICATE";
-        //                }
-        //            }
-        //            else
-        //            {
-        //                var exceptions = _helpRequestsContext.HelpRequestEntities
-        //                    .Where(x => x.Uprn == request.Uprn).ToList();
-        //                if (exceptions.Count > 0)
-        //                {
-        //                    request.RecordStatus = "EXCEPTION";
-        //                }
-        //            }
-        //        }
     }
 }

--- a/cv19ResSupportV3/V3/Gateways/ICallHandlerGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ICallHandlerGateway.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Domain.Commands;
+
+namespace cv19ResSupportV3.V3.Gateways
+{
+    public interface ICallHandlerGateway
+    {
+        List<CallHandler> GetCallHandlers();
+    }
+}

--- a/cv19ResSupportV3/V3/Infrastructure/CallHandlerEntity.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/CallHandlerEntity.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using cv19ResSupportV3.V3.Domain;
+
+namespace cv19ResSupportV3.V3.Infrastructure
+{
+    [Table("call_handlers")]
+    public class CallHandlerEntity
+    {
+        public CallHandlerEntity()
+        {
+
+        }
+
+        [Column("id")]
+        [Key] public int Id { get; set; }
+
+        [Column("name")] public string Name { get; set; }
+
+        [Column("email")] public string Email { get; set; }
+    }
+}

--- a/cv19ResSupportV3/V3/Infrastructure/HelpRequestEntity.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/HelpRequestEntity.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using cv19ResSupportV3.V3.Domain;
 
 namespace cv19ResSupportV3.V3.Infrastructure
 {
@@ -19,6 +18,8 @@ namespace cv19ResSupportV3.V3.Infrastructure
         [Key] public int Id { get; set; }
 
         [Column("resident_id")] [ForeignKey("ResidentEntity")] public int ResidentId { get; set; }
+
+        [Column("call_handler_id")] [ForeignKey("CallHandlerEntity")] public int? CallHandlerId { get; set; }
 
         [Column("is_on_behalf")] public bool? IsOnBehalf { get; set; }
 
@@ -112,6 +113,7 @@ namespace cv19ResSupportV3.V3.Infrastructure
         [Column("metadata", TypeName = "jsonb")] public dynamic Metadata { get; set; }
 
         public ResidentEntity ResidentEntity { get; set; }
+        public CallHandlerEntity CallHandlerEntity { get; set; }
         public List<CaseNoteEntity> CaseNotes { get; set; }
         public List<HelpRequestCallEntity> HelpRequestCalls { get; set; }
 

--- a/cv19ResSupportV3/V3/Infrastructure/HelpRequestEntity.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/HelpRequestEntity.cs
@@ -108,8 +108,6 @@ namespace cv19ResSupportV3.V3.Infrastructure
 
         [Column("nhs_ctas_id")] public string NhsCtasId { get; set; }
 
-        [Column("assigned_staff")] public string AssignedTo { get; set; }
-
         [Column("metadata", TypeName = "jsonb")] public dynamic Metadata { get; set; }
 
         public ResidentEntity ResidentEntity { get; set; }

--- a/cv19ResSupportV3/V3/Infrastructure/HelpRequestsContext.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/HelpRequestsContext.cs
@@ -196,9 +196,6 @@ namespace cv19ResSupportV3.V3.Infrastructure
                        entity.Property(e => e.NhsCtasId)
                            .HasColumnName("nhs_ctas_id")
                            .HasColumnType("character varying");
-                       entity.Property(e => e.AssignedTo)
-                           .HasColumnName("assigned_to")
-                           .HasColumnType("character varying");
                        entity.Property(e => e.Metadata)
                            .HasColumnName("metadata")
                            .HasColumnType("jsonb");

--- a/cv19ResSupportV3/V3/Infrastructure/HelpRequestsContext.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/HelpRequestsContext.cs
@@ -14,7 +14,7 @@ namespace cv19ResSupportV3.V3.Infrastructure
         public DbSet<HelpRequestEntity> HelpRequestEntities { get; set; }
         public DbSet<ResidentEntity> ResidentEntities { get; set; }
         public DbSet<CaseNoteEntity> CaseNoteEntities { get; set; }
-
+        public DbSet<CallHandlerEntity> CallHandlerEntities { get; set; }
 
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -96,6 +96,8 @@ namespace cv19ResSupportV3.V3.Infrastructure
                        entity.Property(e => e.Id).HasColumnName("id");
                        entity.Property(e => e.ResidentId)
                            .HasColumnName("resident_id");
+                       entity.Property(e => e.CallHandlerId)
+                           .HasColumnName("call_handler_id");
                        entity.Property(e => e.IsOnBehalf)
                            .HasColumnName("is_on_behalf")
                            .HasColumnType("bool");
@@ -214,7 +216,21 @@ namespace cv19ResSupportV3.V3.Infrastructure
                            .HasColumnType("character varying");
                        entity.HasOne(e => e.ResidentEntity)
                            .WithMany(c => c.HelpRequests);
+                       entity.HasOne(e => e.CallHandlerEntity);
                    }
+               );
+            modelBuilder.Entity<CallHandlerEntity>(entity =>
+            {
+                entity.ToTable("call_handlers");
+                entity.HasKey(callHandler => new { callHandler.Id });
+                entity.Property(e => e.Id).HasColumnName("id");
+                entity.Property(e => e.Name)
+                    .HasColumnName("name")
+                    .HasColumnType("character varying");
+                entity.Property(e => e.Email)
+                    .HasColumnName("email")
+                    .HasColumnType("character varying");
+            }
                );
             modelBuilder.Entity<CaseNoteEntity>(entity =>
                 {

--- a/cv19ResSupportV3/V3/Infrastructure/Migrations/20211007141406_AddCallHandlersTable.Designer.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/Migrations/20211007141406_AddCallHandlersTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using cv19ResSupportV3.V3.Infrastructure;
@@ -9,9 +10,10 @@ using cv19ResSupportV3.V3.Infrastructure;
 namespace cv19ResSupportV3.V3.Infrastructure.Migrations
 {
     [DbContext(typeof(HelpRequestsContext))]
-    partial class HelpRequestsContextModelSnapshot : ModelSnapshot
+    [Migration("20211007141406_AddCallHandlersTable")]
+    partial class AddCallHandlersTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/cv19ResSupportV3/V3/Infrastructure/Migrations/20211007141406_AddCallHandlersTable.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/Migrations/20211007141406_AddCallHandlersTable.cs
@@ -59,3 +59,4 @@ namespace cv19ResSupportV3.V3.Infrastructure.Migrations
         }
     }
 }
+

--- a/cv19ResSupportV3/V3/Infrastructure/Migrations/20211007141406_AddCallHandlersTable.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/Migrations/20211007141406_AddCallHandlersTable.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace cv19ResSupportV3.V3.Infrastructure.Migrations
+{
+    public partial class AddCallHandlersTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "call_handler_id",
+                table: "help_requests",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "call_handlers",
+                columns: table => new
+                {
+                    id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    name = table.Column<string>(type: "character varying", nullable: true),
+                    email = table.Column<string>(type: "character varying", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_call_handlers", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_help_requests_call_handler_id",
+                table: "help_requests",
+                column: "call_handler_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_help_requests_call_handlers_call_handler_id",
+                table: "help_requests",
+                column: "call_handler_id",
+                principalTable: "call_handlers",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_help_requests_call_handlers_call_handler_id",
+                table: "help_requests");
+
+            migrationBuilder.DropTable(
+                name: "call_handlers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_help_requests_call_handler_id",
+                table: "help_requests");
+
+            migrationBuilder.DropColumn(
+                name: "call_handler_id",
+                table: "help_requests");
+        }
+    }
+}

--- a/cv19ResSupportV3/V3/Infrastructure/Migrations/20211007141406_AddCallHandlersTable.cs
+++ b/cv19ResSupportV3/V3/Infrastructure/Migrations/20211007141406_AddCallHandlersTable.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace cv19ResSupportV3.V3.Infrastructure.Migrations
@@ -59,4 +59,3 @@ namespace cv19ResSupportV3.V3.Infrastructure.Migrations
         }
     }
 }
-

--- a/cv19ResSupportV3/V4/Boundary/Responses/CallHandlerResponseBoundary.cs
+++ b/cv19ResSupportV3/V4/Boundary/Responses/CallHandlerResponseBoundary.cs
@@ -1,0 +1,9 @@
+namespace cv19ResSupportV3.V4
+{
+    public class CallHandlerResponseBoundary
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/cv19ResSupportV3/V4/Controllers/CallHandlersController.cs
+++ b/cv19ResSupportV3/V4/Controllers/CallHandlersController.cs
@@ -10,7 +10,7 @@ using cv19ResSupportV3.V4.UseCase.Interfaces;
 namespace cv19ResSupportV3.V4.Controllers
 {
     [ApiController]
-    [Route("api/v4/callhandlers")]
+    [Route("api/v4/call-handlers")]
     [Produces("application/json")]
     // Check service api version information
     [ApiVersion("3.0")]

--- a/cv19ResSupportV3/V4/Controllers/CallHandlersController.cs
+++ b/cv19ResSupportV3/V4/Controllers/CallHandlersController.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using cv19ResSupportV3.V3.Controllers;
+using cv19ResSupportV3.V3.Domain.Commands;
+using cv19ResSupportV3.V4.UseCase.Interface;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using cv19ResSupportV3.V4.UseCase.Interfaces;
+
+namespace cv19ResSupportV3.V4.Controllers
+{
+    [ApiController]
+    [Route("api/v4/callhandlers")]
+    [Produces("application/json")]
+    // Check service api version information
+    [ApiVersion("3.0")]
+
+    public class CallHandlersController : BaseController
+    {
+        private readonly IGetCallHandlersUseCase _getCallHandlersUseCase;
+
+        public CallHandlersController(
+             IGetCallHandlersUseCase getCallHandlersUseCase)
+        {
+            _getCallHandlersUseCase = getCallHandlersUseCase;
+        }
+
+
+        /// <summary>
+        /// Gets a resident with the id specified.
+        /// </summary>
+        /// <param name="id" example="123">Resident id</param>
+        /// <response code="200">Resident is returned</response>
+        /// <response code="404">...</response>
+        /// <response code="400">...</response>
+        [ProducesResponseType(typeof(List<CallHandlerResponseBoundary>), StatusCodes.Status200OK)]
+        [HttpGet]
+        public IActionResult GetCallHandlers()
+        {
+            var response = _getCallHandlersUseCase.Execute();
+            if (response != null)
+                return Ok(response);
+            return (NotFound("No call handlers not found"));
+        }
+    }
+}

--- a/cv19ResSupportV3/V4/Factories/CallHandlerFactory.cs
+++ b/cv19ResSupportV3/V4/Factories/CallHandlerFactory.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+using cv19ResSupportV3.V3.Domain;
+using cv19ResSupportV3.V3.Domain.Commands;
+using cv19ResSupportV3.V3.Infrastructure;
+
+namespace cv19ResSupportV3.V4.Factories
+{
+    public static class CallHandlerFactory
+    {
+        public static CallHandlerResponseBoundary ToResponse(this CallHandler domain)
+        {
+            return domain == null ? null : new CallHandlerResponseBoundary
+            {
+                Id = domain.Id,
+                Name = domain.Name,
+                Email = domain.Email,
+            };
+        }
+
+        public static CallHandler ToDomain(this CallHandlerEntity callHandler)
+        {
+            return new CallHandler()
+            {
+                Id = callHandler.Id,
+                Name = callHandler.Name,
+                Email = callHandler.Email,
+            };
+        }
+
+        public static List<CallHandlerResponseBoundary> ToResponse(this IEnumerable<CallHandler> callhandlers)
+        {
+            return callhandlers.Select(x => x.ToResponse()).ToList();
+        }
+    }
+}

--- a/cv19ResSupportV3/V4/Factories/ResponseFactory.cs
+++ b/cv19ResSupportV3/V4/Factories/ResponseFactory.cs
@@ -62,7 +62,7 @@ namespace cv19ResSupportV3.V4.Factories
                 HelpNeededSubtype = hr.HelpNeededSubtype,
                 Metadata = hr.Metadata,
                 NhsCtasId = hr.NhsCtasId,
-                AssignedTo = hr.AssignedTo,
+                AssignedTo = hr.CallHandlerEntity?.Name,
                 HelpRequestCalls = hr.HelpRequestCalls.ToDomain()
             };
 

--- a/cv19ResSupportV3/V4/UseCase/GetCallHandlersUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/GetCallHandlersUseCase.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using cv19ResSupportV3.V3.Gateways;
+using cv19ResSupportV3.V4.Factories;
+using cv19ResSupportV3.V4.UseCase.Interface;
+
+namespace cv19ResSupportV3.V4.UseCase
+{
+    public class GetCallHandlersUseCase : IGetCallHandlersUseCase
+    {
+        private readonly ICallHandlerGateway _gateway;
+
+        public GetCallHandlersUseCase(ICallHandlerGateway gateway)
+        {
+            _gateway = gateway;
+        }
+        public List<CallHandlerResponseBoundary> Execute()
+        {
+            var gwResponse = _gateway.GetCallHandlers();
+            return gwResponse.ToResponse();
+        }
+    }
+}

--- a/cv19ResSupportV3/V4/UseCase/Interface/IGetCallHandlersUseCase.cs
+++ b/cv19ResSupportV3/V4/UseCase/Interface/IGetCallHandlersUseCase.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace cv19ResSupportV3.V4.UseCase.Interface
+{
+    public interface IGetCallHandlersUseCase
+    {
+        List<CallHandlerResponseBoundary> Execute();
+    }
+}


### PR DESCRIPTION
# What
- Create call_handlers table to store a list of call handlers.
- Update the API to join on this rather than use the free-text assigned_to column.
- Created a separate script to run after this deployment to populate both call handlers and update call_handler_id. Didn't include as a migration as it contains sensitive data (staff names).

# Why
The call handlers were previously a comma-separated list in a deployment parameter. A developer was required to update and it was disconnected from the data in the database. Now the data is in the API we can build a UI on top of it so a manager can add, remove and edit call handlers.

# Notes
I made the decision to still allow assigned_to to be passed to the API and converted to the call_handler_id when patching a a help request entity. Two reasons:

1. It results in minimal / non-breaking API changes so the API and front-end can still be deployed separately to the API.
2. It's low risk but exposing database IDs should generally be avoided.

