### PR TITLE
Prevent application crash upon encountering unset Nhs Ctas Id fields within the database while deduplicating residents 

### DIFF
--- a/cv19ResSupportV3/V3/Controllers/HelpRequestCallController.cs
+++ b/cv19ResSupportV3/V3/Controllers/HelpRequestCallController.cs
@@ -24,6 +24,7 @@ namespace cv19ResSupportV3.V3.Controllers
         /// Creates a call with the values provided.
         /// </summary>
         /// <param name="id" example="123">Help request id</param>
+        /// <param name="request"></param>
         /// <response code="201">Call is created</response>
         [ProducesResponseType(typeof(HelpRequestCreateResponse), StatusCodes.Status201Created)]
         [HttpPost]
@@ -37,7 +38,7 @@ namespace cv19ResSupportV3.V3.Controllers
                 var result = new HelpRequestCallCreateResponse() { Id = callId };
                 return Created(new Uri($"api/v3/help-requests/{id}/calls/{callId}", UriKind.Relative), result);
             }
-            catch (InvalidOperationException e)
+            catch (InvalidOperationException)
             {
                 return NotFound($"Record with id {id} not found");
             }

--- a/cv19ResSupportV3/V3/Controllers/HelpRequestsController.cs
+++ b/cv19ResSupportV3/V3/Controllers/HelpRequestsController.cs
@@ -83,6 +83,7 @@ namespace cv19ResSupportV3.V3.Controllers
         /// Updates an existing record with the values specified.  This only updates specified editable fields
         /// </summary>
         /// <param name="id" example="123">Help request id</param>
+        /// <param name="request"></param>
         /// <response code="200">The record has been updated</response>
         /// <response code="400">There was an issue updating the record.</response>
         [HttpPatch]

--- a/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/HelpRequestGateway.cs
@@ -68,7 +68,7 @@ namespace cv19ResSupportV3.V3.Gateways
             {
                 propertyInfo = metadata.GetProperty(propertyName).ToString();
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return null;
             };
@@ -97,7 +97,7 @@ namespace cv19ResSupportV3.V3.Gateways
             {
                 propertyInfo = metadata.GetProperty(propertyName).ToString();
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return null;
             };

--- a/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
+++ b/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs
@@ -218,7 +218,7 @@ namespace cv19ResSupportV3.V3.Gateways
                             .Include(r => r.HelpRequests)
                             .AsEnumerable()
                             .FirstOrDefault(r =>
-                                r.HelpRequests.Exists(hr => hr.NhsCtasId.Trim().ToUpper() == command.NhsCtasId.Trim().ToUpper()));
+                                r.HelpRequests.Exists(hr => hr.NhsCtasId?.Trim()?.ToUpper() == command.NhsCtasId.Trim().ToUpper()));
 
                         if (matchingResident != null) return matchingResident.Id;
                     }

--- a/cv19ResSupportV3/V4/Controllers/CaseNotesController.cs
+++ b/cv19ResSupportV3/V4/Controllers/CaseNotesController.cs
@@ -36,8 +36,9 @@ namespace cv19ResSupportV3.V4.Controllers
         /// <summary>
         /// Creates a case note with the values provided.
         /// </summary>
-        /// <param name="id" example="123">Resident id</param>
-        /// <param name="help-request-id" example="456">Help request id</param>
+        /// <param name="residentId" example="123">Resident id</param>
+        /// <param name="helpRequestId" example="456">Help request id</param>
+        /// <param name="caseNote"></param>
         /// <response code="201">...</response>
         [ProducesResponseType(typeof(CaseNoteResponse), StatusCodes.Status201Created)]
         [HttpPost]
@@ -52,7 +53,8 @@ namespace cv19ResSupportV3.V4.Controllers
         /// <summary>
         /// Returns case notes belonging to the resident
         /// </summary>
-        /// <param name="id" example="123">Resident id</param>
+        /// <param name="residentId" example="123">Resident id</param>
+        /// <param name="includeType"></param>
         /// <response code="200">...</response>
         [ProducesResponseType(typeof(List<CaseNoteResponse>), StatusCodes.Status201Created)]
         [HttpGet]
@@ -66,8 +68,9 @@ namespace cv19ResSupportV3.V4.Controllers
         /// <summary>
         /// Returns case notes belonging to the help request
         /// </summary>
-        /// <param name="id" example="123">Resident id</param>
-        /// <param name="help-request-id" example="456">Help request id</param>
+        /// <param name="residentId" example="123">Resident id</param>
+        /// <param name="helpRequestId" example="456">Help request id</param>
+        /// <param name="includeType"></param>
         /// <response code="200">...</response>
         [ProducesResponseType(typeof(List<CaseNoteResponse>), StatusCodes.Status201Created)]
         [HttpGet]

--- a/cv19ResSupportV3/V4/Controllers/ResidentHelpRequestsController.cs
+++ b/cv19ResSupportV3/V4/Controllers/ResidentHelpRequestsController.cs
@@ -40,6 +40,7 @@ namespace cv19ResSupportV3.V4.Controllers
         /// Creates a resident help request with the values provided.
         /// </summary>
         /// <param name="id" example="123">Resident id</param>
+        /// <param name="request"></param>
         /// <response code="201">Help request is created</response>
         [ProducesResponseType(typeof(ResidentHelpRequestResponse), StatusCodes.Status201Created)]
         [HttpPost]
@@ -53,7 +54,8 @@ namespace cv19ResSupportV3.V4.Controllers
         /// Gets a resident help request with the id specified.
         /// </summary>
         /// <param name="id" example="123">Resident id</param>
-        /// <param name="help-request-id" example="456">Help request id</param>
+        /// <param name="helpRequestId"></param>
+        /// <param name="includeType"></param>
         /// <response code="200">Help request is returned</response>
         /// <response code="404">...</response>
         [ProducesResponseType(typeof(ResidentHelpRequestResponse), StatusCodes.Status200OK)]
@@ -74,6 +76,7 @@ namespace cv19ResSupportV3.V4.Controllers
         /// Gets a collection of help requests for a resident with the id specified.
         /// </summary>
         /// <param name="id" example="123">Resident id</param>
+        /// <param name="includeType"></param>
         /// <response code="200">List of help requests is returned</response>
         /// <response code="404">...</response>
         [ProducesResponseType(typeof(List<ResidentHelpRequestResponse>), StatusCodes.Status200OK)]
@@ -92,7 +95,8 @@ namespace cv19ResSupportV3.V4.Controllers
         /// Updates a help request with the id specified.
         /// </summary>
         /// <param name="id" example="123">Resident id</param>
-        /// <param name="help-request-id" example="456">Help request id</param>
+        /// <param name="helpRequestId"></param>
+        /// <param name="request"></param>
         /// <response code="200">Help request is updated</response>
         /// <response code="404">...</response>
         [ProducesResponseType(typeof(ResidentResponseBoundary), StatusCodes.Status200OK)]

--- a/cv19ResSupportV3/V4/Controllers/ResidentsController.cs
+++ b/cv19ResSupportV3/V4/Controllers/ResidentsController.cs
@@ -85,6 +85,7 @@ namespace cv19ResSupportV3.V4.Controllers
         /// Updates a resident with the id specified.
         /// </summary>
         /// <param name="id" example="123">Resident id</param>
+        /// <param name="request"></param>
         /// <response code="200">Resident has been updated</response>
         /// <response code="404">...</response>
         [ProducesResponseType(typeof(ResidentResponseBoundary), StatusCodes.Status200OK)]


### PR DESCRIPTION
# What:
 - Changes to prevent application from crashing when encountering null Nhs Ctas Ids within the database while deduplicating residents.
 - Automatic formatting changes with a bit of manual intervention that are likely coming from updated linter.

# Why:
- So that every resident could be ingested via H2H ingestion process, regardless of what value were historically set within the database. 

# Notes:
- This branch was rebased from master to development, hence, the rewriting of history. This will be related to #145 later down the merge line when the changes will be changed from dev to master.

